### PR TITLE
docs: refine simulator spec for minimal initial implementation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,1068 @@
+# ROS2 Race Simulator
+## Architecture Design
+
+---
+
+## 1. 文書の目的
+
+本書は、ROS2 Race Simulator のアーキテクチャ設計を定義する文書である。  
+要件定義および仕様書に基づき、以下を明確化することを目的とする。
+
+- システム全体の責務分割
+- ノード間の関係
+- topic / message を介したデータフロー
+- backend と上流ロジックの分離方針
+- map / track / scenario の境界
+- 将来の CARLA 拡張を見据えた adapter / bridge 方針
+- 実装時に崩してはいけない設計原則
+
+本書は、実装前にシステム構造を固定し、実装時の責務逸脱や構造破綻を防ぐための設計文書である。
+
+---
+
+## 2. 設計の基本方針
+
+本システムは、**simulator-independent な ROS2 システム**として設計する。
+
+初版では軽量な internal simulator backend を使うが、将来的に CARLA backend に置換できることを前提とする。
+
+### 2.1 設計方針
+
+- controller は simulator backend に依存しない
+- race logic は simulator backend に依存しない
+- visualization は race logic に依存しない
+- simulator 固有コードは bridge / adapter 層に隔離する
+- track は file + shared library で扱う
+- external map asset は track と分離して扱う
+- vehicle ごとに namespace を分ける
+- レース全体情報は `/race/...` に集約する
+
+### 2.2 重要な原則
+
+本システムのアーキテクチャでは、以下を強く守る。
+
+1. **車両制御 I/F の固定**
+   - `/carX/cmd_drive`
+
+2. **車両状態 I/F の固定**
+   - `/carX/odom`
+   - `odom -> carX/base_link`
+
+3. **レース管理 I/F の固定**
+   - `/race/command`
+   - `/race/state`
+   - `/race/lap_event`
+   - `/race/vehicle_status`
+
+4. **backend 差し替え可能性の確保**
+   - internal backend でも CARLA backend でも、上流には同じ interface を見せる
+
+---
+
+## 2.3 Node Internal Design Principle
+各ノードは ROS2 I/O と内部ロジックを分離することを原則とする。
+
+### 2.3.1 ROS 依存部
+ROS 依存部は以下に限定する。
+- publisher / subscriber
+- parameter 読み込み
+- timer
+- clock 取得
+- TF broadcast
+- launch / lifecycle に関わる処理
+
+### 2.3.2 ROS 非依存部
+計算ロジックは可能な限り ROS 非依存の class / function として分離する。
+例:
+- VehicleDynamics
+- TrackGeometry
+- LapDetector
+- OffTrackChecker
+- ControllerBase
+- PurePursuitController
+
+### 2.3.3 目的
+この分離により以下を実現する。
+- 単体テスト容易性
+- simulator backend 差し替え時の再利用性
+- ROS ノード肥大化の防止
+
+
+---
+## 3. システム全体構造
+
+本システムは、概念的に以下のレイヤ構造で構成される。
+
+~~~text
+Controller Layer
+    │
+    ▼
+Drive Command Interface
+    │
+    ▼
+Vehicle Simulation Backend
+    │
+    ▼
+Vehicle State Interface
+    │
+    ▼
+Race Logic Layer
+    │
+    ▼
+Visualization Layer
+~~~
+
+### 3.1 Controller Layer
+
+各車両に対して制御入力を生成する層。
+
+#### 構成要素
+- `gamepad_input_node`
+- `keyboard_input_node`
+- `ai_driver_node`
+
+#### 出力
+- `/carX/cmd_drive`
+
+#### 特徴
+- 手動入力と AI 入力の source を分離する
+- controller 種別が変わっても `DriveCommand` の message 契約は変えない
+- 同一車両について manual input source は 1つだけ有効にする
+
+---
+
+### 3.2 Drive Command Interface
+
+全ての車両制御入力を統一的に扱う I/F。
+
+#### topic
+- `/carX/cmd_drive`
+
+#### message
+- `race_interfaces/DriveCommand`
+
+#### 目的
+- 手動操作と AI 操作を統一
+- vehicle backend を差し替えても制御インターフェースを保つ
+- 将来、Stanley / MPC / external control node を追加しやすくする
+
+---
+
+### 3.3 Vehicle Simulation Backend
+
+車両運動を計算し、ROS2 上の標準化された車両状態を生成する層。
+
+#### 初版 backend
+- `vehicle_sim_node`
+
+#### 将来 backend
+- `race_carla_bridge` + `CARLA`
+
+#### 標準出力
+- `/carX/odom`
+- `odom -> carX/base_link`
+
+#### 目的
+- controller から受けた DriveCommand を車両状態へ変換する
+- 上流ロジックに simulator 非依存の車両状態を提供する
+
+---
+
+### 3.4 Vehicle State Interface
+
+車両状態を表す共通 I/F。
+
+#### topic
+- `/carX/odom`
+
+#### message
+- `nav_msgs/Odometry`
+
+#### TF
+- `odom -> carX/base_link`
+
+#### 目的
+- race logic
+- AI control
+- renderer
+
+が共通の状態 source を扱えるようにする
+
+---
+
+### 3.5 Race Logic Layer
+
+レース全体の進行を管理する層。
+
+#### 主担当ノード
+- `race_manager_node`
+
+#### 扱う機能
+- RaceState の管理
+- Lap 判定
+- elapsed time 計測
+- off-track 判定
+- `VehicleRaceStatus` の生成
+- `LapEvent` の生成
+
+#### 特徴
+- 表示都合を持たない
+- backend に依存しない
+- track は shared library から読む
+- simulator 固有 topic を直接読まない
+
+---
+
+### 3.6 Visualization Layer
+
+状態を可視化する層。
+
+#### 初版
+- `renderer_node`
+
+#### 将来
+- simulator-native visualization
+- CARLA の可視化系
+- 他 frontend
+
+#### 特徴
+- 表示専用
+- race logic を持たない
+- 継続状態は `VehicleRaceStatus` を真とする
+- 一時イベントは `LapEvent` を使う
+
+---
+
+## 4. ノード一覧と責務
+
+### 4.1 `vehicle_sim_node`
+
+#### 役割
+1台の車両の簡易運動シミュレーションを行う internal backend。
+
+#### 主責務
+- `DriveCommand` の購読
+- command timeout 処理
+- Kinematic Bicycle Model による状態更新
+- `/carX/odom` publish
+- `odom -> carX/base_link` TF broadcast
+- `RESET` による初期化
+
+#### やらないこと
+- lap 判定
+- off-track 判定
+- race state 管理
+- 表示
+
+#### 内部設計原則
+`vehicle_sim_node` は ROS node であるが、車両運動計算や入力変換は ROS 非依存 class に分離する。
+例:
+- `VehicleDynamics`
+- `DriveCommandAdapter`
+- `VehicleState`
+- `OdometryConverter`
+
+
+#### アーキテクチャ上の位置づけ
+初版の internal backend であり、将来的には external backend に置換可能なコンポーネント。
+
+---
+
+### 4.2 `ai_driver_node`
+
+#### 役割
+1台の AI 車両に対して、自動走行用 `DriveCommand` を生成する。
+
+#### 主責務
+- `/carX/odom` 購読
+- `/race/state` 購読
+- track の読み込み
+- target point 選択
+- steering 計算
+- speed 制御
+- `/carX/cmd_drive` publish
+
+#### 対応 controller
+- `pure_pursuit`
+- `pid_heading`
+
+#### やらないこと
+- lap 判定
+- off-track 判定
+- race state 遷移
+- simulator 固有 API 利用
+
+#### アーキテクチャ上の位置づけ
+simulator-independent な controller 層の一部。
+
+---
+
+### 4.3 `race_manager_node`
+
+#### 役割
+レース全体の進行を管理する central logic node。
+
+#### 主責務
+- `/race/command` 購読
+- `/carX/odom` 購読
+- RaceState 管理
+- Lap 判定
+- elapsed time 計測
+- off-track 判定
+- `/race/state` publish
+- `/race/lap_event` publish
+- `/race/vehicle_status` publish
+
+#### やらないこと
+- 車両運動計算
+- controller 計算
+- 表示レイアウトや UI 文字列加工
+- UI 用文字列生成
+- simulator 固有 API 呼び出し
+- renderer のためだけの補助状態保持
+
+
+#### アーキテクチャ上の位置づけ
+本システムのルールエンジン。
+
+---
+
+### 4.4 `renderer_node`
+
+#### 役割
+レース状態を 2D で可視化する暫定 frontend。
+
+#### 主責務
+- `/carX/odom` 購読
+- `/race/state` 購読
+- `/race/vehicle_status` 購読
+- `/race/lap_event` 購読
+- track の読み込み
+- コース描画
+- 車両描画
+- HUD 表示
+- LapEvent の一時表示
+
+#### やらないこと
+- lap 判定
+- off-track 計算
+- RaceState 遷移
+- backend 制御
+
+#### アーキテクチャ上の位置づけ
+初版におけるデバッグ・観測用 frontend。
+本番品質の UI や高機能 GUI を目指さず、状態確認のための最小表示に徹する。
+将来的に simulator-native visualization に置換可能である。
+
+
+---
+
+### 4.5 `gamepad_input_node`
+
+#### 役割
+gamepad から DriveCommand を生成する。
+
+#### 主責務
+- joystick 読み取り
+- 入力正規化
+- deadzone 適用
+- `/carX/cmd_drive` publish
+
+#### やらないこと
+- race command 発行
+- race state 管理
+- 車両状態計算
+
+---
+
+### 4.6 `keyboard_input_node`
+
+#### 役割
+キーボードから DriveCommand を生成する。
+
+#### 主責務
+- キー入力取得
+- `/carX/cmd_drive` publish
+
+#### 用途
+- fallback
+- debug
+
+---
+
+### 4.7 `race_command_input_node`
+
+#### 役割
+レース全体制御コマンドを生成する。
+
+#### 主責務
+- START
+- STOP
+- RESET
+の発行
+
+#### 出力
+- `/race/command`
+
+#### 設計意図
+車両操作入力とレース操作入力を分離する。
+
+---
+
+### 4.8 `race_carla_bridge`（将来）
+
+#### 役割
+CARLA と ROS2 システム標準 I/F の橋渡し。
+
+#### 主責務
+- `/carX/cmd_drive` → CARLA vehicle control
+- CARLA vehicle state → `/carX/odom`
+- CARLA state → TF
+- 将来の sensor stream → ROS2 topic
+
+#### アーキテクチャ上の位置づけ
+simulator-specific code を隔離する adapter / bridge 層。
+
+---
+
+## 5. Vehicle Namespace Architecture
+
+各車両は独立した namespace を持つ。
+
+### 5.1 目的
+- 多車両で topic が衝突しないようにする
+- launch で同一ノードを複数起動しやすくする
+- vehicle_id と topic / frame の対応を明確にする
+- controller 比較をしやすくする
+
+### 5.2 namespace 例
+
+~~~text
+/car1
+/car2
+/car3
+~~~
+
+### 5.3 車両固有 topic
+
+~~~text
+/carX/cmd_drive
+/carX/odom
+~~~
+
+### 5.4 車両固有 frame
+
+~~~text
+carX/base_link
+~~~
+
+### 5.5 race-wide topic
+
+~~~text
+/race/command
+/race/state
+/race/lap_event
+/race/vehicle_status
+~~~
+
+### 5.6 命名制約
+以下は一致させる。
+
+- `vehicle_id`
+- namespace
+- frame 接頭辞
+
+例:
+- `vehicle_id = car2`
+- namespace = `/car2`
+- frame = `car2/base_link`
+
+---
+
+## 6. Topic / Message アーキテクチャ
+
+### 6.1 車両制御入力
+
+#### topic
+- `/carX/cmd_drive`
+
+#### message
+- `race_interfaces/DriveCommand`
+
+#### publisher
+- `gamepad_input_node`
+- `keyboard_input_node`
+- `ai_driver_node`
+
+#### subscriber
+- `vehicle_sim_node`
+- 将来 `race_carla_bridge`
+
+#### 設計意図
+すべての controller source を共通 I/F で統一する。
+
+---
+
+### 6.2 車両状態
+
+#### topic
+- `/carX/odom`
+
+#### message
+- `nav_msgs/Odometry`
+
+#### publisher
+- `vehicle_sim_node`
+- 将来 `race_carla_bridge`
+
+#### subscriber
+- `race_manager_node`
+- `ai_driver_node`
+- `renderer_node`
+
+#### 設計意図
+race logic と AI と renderer の共通状態 source とする。
+
+---
+
+### 6.3 レース制御
+
+#### topic
+- `/race/command`
+
+#### message
+- `race_interfaces/RaceCommand`
+
+#### publisher
+- `race_command_input_node`
+- 将来 GUI
+- 将来 external frontend
+
+#### subscriber
+- `race_manager_node`
+- `vehicle_sim_node`
+
+#### 設計意図
+レース全体 command を 1本化する。
+
+---
+
+### 6.4 レース全体状態
+
+#### topic
+- `/race/state`
+
+#### message
+- `race_interfaces/RaceState`
+
+#### publisher
+- `race_manager_node`
+
+#### subscriber
+- `ai_driver_node`
+- `renderer_node`
+
+#### 設計意図
+AI と renderer がレース進行状態を共通認識できるようにする。
+
+---
+
+### 6.5 ラップイベント
+
+#### topic
+- `/race/lap_event`
+
+#### message
+- `race_interfaces/LapEvent`
+
+#### publisher
+- `race_manager_node`
+
+#### subscriber
+- `renderer_node`
+- 将来 logger / analytics
+
+#### 設計意図
+event-driven な通知専用 I/F とする。
+
+---
+
+### 6.6 車両ごとのレース状態
+
+#### topic
+- `/race/vehicle_status`
+
+#### message
+- `race_interfaces/VehicleRaceStatus`
+
+#### publisher
+- `race_manager_node`
+
+#### subscriber
+- `renderer_node`
+
+#### 設計意図
+継続表示の真実の source とする。  
+1車両1メッセージを流し、`vehicle_id` で識別する。
+
+---
+
+## 7. Message 設計の考え方
+
+### 7.1 custom message の範囲
+custom message は以下に限定する。
+
+- `DriveCommand`
+- `RaceCommand`
+- `RaceState`
+- `LapEvent`
+- `VehicleRaceStatus`
+
+### 7.2 標準 message の利用
+車両状態は ROS標準 message を使う。
+
+- `nav_msgs/Odometry`
+
+### 7.3 Track.msg を作らない理由
+初版では track を topic で流さず、shared library と file で扱うため。
+
+その理由:
+- topic と node を増やしすぎない
+- 初版の責務を軽く保つ
+- 将来必要なら Track.msg を追加できる
+
+---
+
+## 8. Race Logic アーキテクチャ
+
+### 8.1 RaceState Machine
+
+状態:
+
+- `READY`
+- `COUNTDOWN`
+- `RUNNING`
+- `FINISHED`
+- `STOPPED`
+
+遷移:
+
+- `READY --START--> COUNTDOWN`
+- `COUNTDOWN --timeout--> RUNNING`
+- `RUNNING --finish--> FINISHED`
+- `COUNTDOWN/RUNNING --STOP--> STOPPED`
+- `STOPPED/FINISHED --RESET--> READY`
+
+### 8.2 elapsed_time
+- `RUNNING` 開始時から加算
+- `COUNTDOWN` は含めない
+- `STOPPED` / `FINISHED` で停止
+
+### 8.3 Lap Detection
+ラップ成立条件:
+
+1. start_line 交差
+2. forward_hint と move_vec が整合
+3. cooldown 超過
+4. `RUNNING`
+5. `has_finished == false`
+6. odom 受信済み
+
+### 8.4 Off-track Detection
+- centerline 最近点距離で判定
+- `distance > track_width / 2`
+- `inside -> outside` で `off_track_count += 1`
+
+### 8.5 RaceManager の責務境界
+RaceManager が持つ:
+- 判定
+- 状態更新
+- レース進行
+
+RaceManager が持たない:
+- vehicle dynamics
+- controller logic
+- renderer 表示整形
+- simulator-specific API
+
+---
+
+## 9. AI Control Architecture
+
+### 9.1 基本構造
+
+`ai_driver_node` は simulator-independent な controller node とする。
+
+入力:
+- `/carX/odom`
+- `/race/state`
+- track file
+
+出力:
+- `/carX/cmd_drive`
+
+### 9.2 Controller 切替
+初版で対応する controller:
+- `pure_pursuit`
+- `pid_heading`
+
+将来追加候補:
+- `stanley`
+- `mpc`
+
+### 9.3 target point selection
+- 毎周期最近点を再計算
+- lookahead point を選択
+- off-track しても復帰しやすい構造にする
+
+### 9.4 internal structure 例
+
+~~~text
+TrackFollower
+TargetPointSelector
+ControllerBase
+ ├ PurePursuitController
+ └ PidHeadingController
+SpeedController
+~~~
+
+### 9.5 AI driver がやらないこと
+- lap 判定
+- off-track 判定
+- race state 遷移
+- 他車回避
+- overtaking
+- simulator-specific state handling
+
+---
+
+## 10. Visualization Architecture
+
+### 10.1 renderer の位置づけ
+`renderer_node` は初版の暫定 visualization frontend である。
+
+### 10.2 renderer の責務
+- course 描画
+- vehicle 描画
+- HUD 表示
+- LapEvent の一時表示
+
+### 10.3 renderer の入力
+- `/carX/odom`
+- `/race/state`
+- `/race/vehicle_status`
+- `/race/lap_event`
+- track file
+
+### 10.4 renderer の制約
+- race logic を持たない
+- off-track 判定を行わない
+- lap 計算を行わない
+- 継続表示の真実は `VehicleRaceStatus`
+- `LapEvent` は一時通知に限定
+
+### 10.5 将来の置換性
+将来、renderer は以下に置換可能である。
+
+- simulator-native visualization
+- CARLA visualization
+- external frontend
+
+---
+
+## 11. Track / Map / Scenario アーキテクチャ
+
+### 11.1 なぜ分離するか
+外部 map asset と race logic 用 course と runtime 条件は役割が異なるため。
+
+### 11.2 Physical / Environment Map
+外部環境地図を表す。
+
+例:
+- OpenDRIVE
+- simulator map
+- competition-provided map
+
+責務:
+- `race_map`
+
+### 11.3 Logical Race Track
+レースや評価に使う logical course。
+
+保持する情報:
+- centerline
+- start_line
+- forward_hint
+- track_width
+
+責務:
+- `race_track`
+
+### 11.4 Scenario
+runtime 条件を表す。
+
+例:
+- 車両配置
+- manual / AI 割り当て
+- controller_type
+- race settings
+
+### 11.5 重要な設計原則
+external map を logical track と同一視しない。  
+必要に応じて map adaptation によって logical track を生成する。
+
+---
+
+## 12. race_track アーキテクチャ
+
+### 12.1 位置づけ
+`race_track` は node ではなく shared library である。
+
+### 12.2 提供機能
+- YAML parse
+- validation
+- TrackModel 生成
+- 最近点計算
+- distance 計算
+- lookahead 計算補助
+- start_line 交差判定補助
+- `forward_hint`, `track_width`, `start_line` 取得
+
+### 12.3 使用ノード
+- `ai_driver_node`
+- `race_manager_node`
+- `renderer_node`
+
+### 12.4 TrackModel
+最低限保持するもの:
+- `track_name`
+- `centerline`
+- `track_width`
+- `start_line`
+- `forward_hint`
+
+---
+
+## 13. race_map アーキテクチャ
+
+### 13.1 位置づけ
+`race_map` は external map asset を扱うための package である。
+
+### 13.2 主目的
+- external map asset の読み込み
+- OpenDRIVE parse
+- normalization
+- logical track 生成支援
+
+### 13.3 主形式
+- OpenDRIVE を第一候補とする
+
+### 13.4 将来の利用方法
+- OpenDRIVE → logical race track
+- simulator map → logical race track
+- competition-provided map → logical race track
+
+### 13.5 race_track との境界
+- `race_map`: physical map
+- `race_track`: logical track
+
+この分離を崩さない。
+
+---
+
+## 14. Backend 差し替えアーキテクチャ
+
+### 14.1 初版 backend
+- `vehicle_sim_node`
+
+### 14.2 将来 backend
+- `race_carla_bridge` + `CARLA`
+
+### 14.3 bridge / adapter の役割
+simulator 固有 interface を ROS2 system standard interface に変換する。
+
+### 14.4 上流ロジックが依存する I/F
+- `/carX/cmd_drive`
+- `/carX/odom`
+- `odom -> carX/base_link`
+
+### 14.5 期待される効果
+- internal backend でも future backend でも上流ロジックを再利用できる
+- RaceManager / AI Driver / Renderer の作り直しを避ける
+
+---
+
+## 15. パッケージ構成アーキテクチャ
+
+想定パッケージ:
+
+- `race_interfaces`
+- `race_track`
+- `race_map`
+- `race_vehicle`
+- `race_ai`
+- `race_manager`
+- `race_renderer`
+- `race_input`
+- `race_bringup`
+- `race_carla_bridge`
+
+### 15.1 `race_interfaces`
+custom message 定義
+
+### 15.2 `race_track`
+logical track shared library
+
+### 15.3 `race_map`
+external map asset package
+
+### 15.4 `race_vehicle`
+`vehicle_sim_node`
+
+### 15.5 `race_ai`
+`ai_driver_node`
+
+### 15.6 `race_manager`
+`race_manager_node`
+
+### 15.7 `race_renderer`
+`renderer_node`
+
+### 15.8 `race_input`
+- `gamepad_input_node`
+- `keyboard_input_node`
+- `race_command_input_node`
+
+### 15.9 `race_bringup`
+launch / config / scenario 読み込み
+
+### 15.10 `race_carla_bridge`
+future simulator bridge
+
+---
+
+## 16. 設計制約
+
+本アーキテクチャで絶対に崩してはいけない制約を以下に示す。
+
+### 16.1 Interface 固定
+- 車両制御 I/F は `/carX/cmd_drive`
+- 車両状態 I/F は `/carX/odom`
+- race-wide I/F は `/race/...`
+
+### 16.2 Namespace 一貫性
+- `vehicle_id`
+- namespace
+- frame prefix
+は一致させる
+
+### 16.3 renderer は表示専用
+- 判定を持たない
+- race state 更新を持たない
+
+### 16.4 race_manager は判定専用
+- vehicle dynamics を持たない
+- renderer 表示都合を持たない
+
+### 16.5 simulator-specific code の隔離
+simulator 固有処理は bridge / adapter に隔離する
+
+### 16.6 map / track / scenario の境界維持
+- map = physical environment
+- track = logical race course
+- scenario = runtime condition
+
+### 16.7 track の扱い
+初版で track は topic 配信しない。  
+file + library で扱う。
+
+### 16.8 時間源の一貫性
+全ノードの時間計算は ROS clock を唯一の正とする。
+- countdown
+- cooldown
+- lap timing
+- elapsed time
+はすべて ROS time で計算する。
+time source の混在を禁止する。
+
+### 16.9 初版の抽象化抑制
+初版では将来拡張のための過剰な抽象化を避ける。
+- 未使用 backend のための plugin 機構を先行導入しない
+- 未使用 controller のための汎用化を行いすぎない
+- 実際の使用箇所が出るまで interface を増やしすぎない
+
+---
+
+## 17. 将来拡張の見取り図
+
+### 17.1 simulator
+- CARLA
+- 将来 Isaac Sim なども候補になりうる
+
+### 17.2 sensor
+- LiDAR
+- Radar
+- Camera
+
+### 17.3 controller
+- Stanley
+- MPC
+
+### 17.4 map source
+- OpenDRIVE
+- simulator map
+- competition map
+
+### 17.5 autonomy stack
+- perception
+- planning
+- control
+
+---
+
+## 18. 実装順とアーキテクチャの関係
+
+推奨実装順:
+
+1. `race_interfaces`
+2. `race_track`
+3. `vehicle_sim_node`
+4. `race_manager_node`
+5. `gamepad_input_node` / `keyboard_input_node` / `race_command_input_node`
+6. `renderer_node`
+7. `ai_driver_node`
+
+### 理由
+- 依存の少ないものから固める
+- 各段階で inspect 可能な状態を作る
+- architecture を崩さずに前進できる
+
+---
+
+## 19. 本書の位置づけ
+
+本書は、以下の基準となる architecture document である。
+
+- 実装タスク分解
+- GitHub Issues
+- README / docs
+- backend 差し替え時の指針
+- future CARLA integration design
+
+本書に定義した責務分離と interface 契約を維持することを、本プロジェクトの構造上の前提とする。
+
+---
+
+## 初版開発ポリシー
+本プロジェクトの初版では、「軽量な internal backend により、ROS2 システム設計を成立させること」を最優先とする。
+
+そのため、以下を厳守する。
+- 動く最小構成を優先する
+- 各段階で build / run / inspect 可能な状態を維持する
+- 将来拡張のための過剰実装を行わない
+- 未使用の抽象層や plugin 機構を先行導入しない
+- renderer の高機能化を優先しない
+- race logic / vehicle dynamics / controller / visualization の責務境界を崩さない
+- 初版 acceptance criteria を満たすまで、将来機能には着手しない
+
+

--- a/docs/implementation_tasks.md
+++ b/docs/implementation_tasks.md
@@ -1,0 +1,1601 @@
+# ROS2 Race Simulator
+## Implementation Tasks
+
+---
+
+## 1. 文書の目的
+
+本書は、ROS2 Race Simulator の仕様とアーキテクチャをもとに、実装作業を実行可能な粒度まで分解したタスク一覧である。
+
+目的は以下の通り。
+
+- どの順番で何を作るかを明確にする
+- GitHub Issues にそのまま転記できる粒度にする
+- 各タスクの完了条件を定義する
+- 実装時に迷わないようにする
+- 「今どこまでできているか」を追跡できるようにする
+
+本書では、以下の観点でタスクを整理する。
+
+- フェーズごとの実装順
+- 各タスクの目的
+- 実装内容
+- 完了条件
+- 依存関係
+- optional / future 扱い
+
+---
+
+## 2. 実装方針
+
+### 2.1 基本方針
+
+実装は以下の順で進める。
+
+1. interface を固定する
+2. shared library を作る
+3. internal backend を作る
+4. race logic を作る
+5. input をつなぐ
+6. visualization をつなぐ
+7. AI をつなぐ
+
+### 2.2 なぜこの順番か
+
+この順番を採用する理由は以下の通り。
+
+- 依存関係の少ないものから作れる
+- 各段階で build / run / inspect が可能
+- 「全部できるまで何も確認できない」状態を避けられる
+- backend と上流ロジックを分離した設計を崩さない
+
+### 2.3 実装の考え方
+
+- 最初から全部作らない
+- 各フェーズで「動く最小構成」を作る
+- まず internal backend で成立させる
+- controller 比較や CARLA 連携は後段で扱う
+- 将来拡張は設計に入れるが、初版実装を重くしない
+
+### 2.4 Phase Completion Rule
+各 Phase は、その Phase の最小動作確認が完了するまで次へ進まない。
+新機能の先行実装や将来拡張の着手は禁止する。
+
+### 2.5 初版実装の禁止事項
+初版 acceptance criteria を満たすまで、以下への着手を禁止する。
+- OpenDRIVE 対応
+- CARLA 連携
+- sensor topic 生成
+- collision 判定
+- overtaking
+- renderer 高機能化
+- controller の追加拡張
+
+
+---
+
+## 3. 実装フェーズ一覧
+
+本プロジェクトは以下のフェーズに分けて実装する。
+
+- Phase 0: Repository / Workspace Setup
+- Phase 1: Interfaces
+- Phase 2: Track Library
+- Phase 3: Vehicle Backend
+- Phase 4: Race Logic
+- Phase 5: Input Nodes
+- Phase 6: Renderer
+- Phase 7: AI Driver
+- Phase 8: Bringup / Scenario
+- Phase 9: Test / Quality
+- Phase 10: Future Extensions (Optional)
+
+---
+
+## 4. Phase 0: Repository / Workspace Setup
+
+### Task 0-1: ROS2 workspace 作成
+
+#### 目的
+開発全体の作業基盤を作る。
+
+#### 作業内容
+- ROS2 workspace を作成する
+- `src/` 配下にパッケージを配置できる状態を作る
+
+#### 想定構成
+
+~~~text
+race_simulator_ws/
+ ├─ src/
+ ├─ build/
+ ├─ install/
+ └─ log/
+~~~
+
+#### 完了条件
+- workspace が作成されている
+- `colcon build` を実行できる
+
+#### 依存
+- なし
+
+---
+
+### Task 0-2: パッケージ skeleton 作成
+
+#### 目的
+プロジェクトの実装単位となる ROS2 パッケージを作成する。
+
+#### 作業内容
+以下のパッケージを作成する。
+
+- `race_interfaces`
+- `race_track`
+- `race_map`
+- `race_vehicle`
+- `race_ai`
+- `race_manager`
+- `race_renderer`
+- `race_input`
+- `race_bringup`
+- `race_carla_bridge`
+
+#### 完了条件
+- 全パッケージが `src/` に作成されている
+- `ros2 pkg list` で見える
+- 空の状態で `colcon build` が通る
+
+#### 依存
+- Task 0-1
+
+---
+
+### Task 0-3: ドキュメント配置
+
+#### 目的
+要件・仕様・アーキテクチャ・タスク一覧をリポジトリ上に格納する。
+
+#### 作業内容
+以下の文書を配置する。
+
+- `docs/requirements.md`
+- `docs/specification.md`
+- `docs/architecture.md`
+- `docs/implementation_tasks.md`
+
+#### 完了条件
+- docs ディレクトリに文書が存在する
+- リポジトリのトップから参照できる
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 0-4: ルート README の初版作成
+
+#### 目的
+リポジトリの入口を用意する。
+
+#### 作業内容
+README に以下を記載する。
+
+- プロジェクト概要
+- 目的
+- パッケージ一覧
+- docs へのリンク
+- 開発の進め方
+
+#### 完了条件
+- README を読めばプロジェクトの全体像が分かる
+
+#### 依存
+- Task 0-3
+
+---
+
+## 5. Phase 1: Interfaces
+
+### Task 1-1: `DriveCommand.msg` 作成
+
+#### 目的
+車両制御入力の共通 interface を定義する。
+
+#### 内容
+
+~~~text
+std_msgs/Header header
+
+float32 throttle_cmd
+float32 steering_cmd
+~~~
+
+#### 完了条件
+- `ros2 interface show race_interfaces/msg/DriveCommand` で確認できる
+- build が通る
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 1-2: `RaceCommand.msg` 作成
+
+#### 目的
+レース操作 command の共通 interface を定義する。
+
+#### 内容
+
+~~~text
+std_msgs/Header header
+
+uint8 command
+
+uint8 START=0
+uint8 STOP=1
+uint8 RESET=2
+~~~
+
+#### 完了条件
+- interface が定義されている
+- build が通る
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 1-3: `RaceState.msg` 作成
+
+#### 目的
+レース全体状態の interface を定義する。
+
+#### 内容
+
+~~~text
+std_msgs/Header header
+
+string race_status
+builtin_interfaces/Duration elapsed_time
+
+int32 total_laps
+~~~
+
+#### 完了条件
+- interface が定義されている
+- build が通る
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 1-4: `LapEvent.msg` 作成
+
+#### 目的
+ラップ成立時イベントの interface を定義する。
+
+#### 内容
+
+~~~text
+std_msgs/Header header
+
+string vehicle_id
+
+int32 lap_count
+
+builtin_interfaces/Duration lap_time
+builtin_interfaces/Duration best_lap_time
+
+bool has_finished
+~~~
+
+#### 完了条件
+- interface が定義されている
+- build が通る
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 1-5: `VehicleRaceStatus.msg` 作成
+
+#### 目的
+車両ごとの継続レース状態の interface を定義する。
+
+#### 内容
+
+~~~text
+std_msgs/Header header
+
+string vehicle_id
+
+int32 lap_count
+
+builtin_interfaces/Duration current_lap_time
+builtin_interfaces/Duration last_lap_time
+builtin_interfaces/Duration best_lap_time
+builtin_interfaces/Duration total_elapsed_time
+
+bool has_finished
+bool is_off_track
+
+int32 off_track_count
+~~~
+
+#### 完了条件
+- interface が定義されている
+- build が通る
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 1-6: custom message 定義の整合確認
+
+#### 目的
+仕様書と message 定義が一致していることを確認する。
+
+#### 作業内容
+- 型が仕様通りか確認
+- enum 値が仕様通りか確認
+- Header / Duration が仕様通りか確認
+
+#### 完了条件
+- 仕様書との差分がない
+
+#### 依存
+- Task 1-1 ～ 1-5
+
+---
+
+## 6. Phase 2: Track Library
+
+### Task 2-1: `TrackModel` クラス作成
+
+#### 目的
+track file の論理表現をコード上で統一する。
+
+#### 保持項目
+- `track_name`
+- `centerline`
+- `track_width`
+- `start_line`
+- `forward_hint`
+
+#### 完了条件
+- `TrackModel` をインスタンス化できる
+- 最低限のデータ構造が定義されている
+
+#### 依存
+- Task 0-2
+
+---
+
+### Task 2-2: track YAML loader 実装
+
+#### 目的
+track file を読み込み、`TrackModel` に変換する。
+
+#### 作業内容
+- YAML parser 実装
+- `TrackModel` 生成
+- 読み込み失敗時の例外処理
+
+#### 完了条件
+- `sample_track.yaml` を読み込める
+- 不正 YAML で明示的に失敗する
+
+#### 依存
+- Task 2-1
+
+---
+
+### Task 2-3: track validation 実装
+
+#### 目的
+不正な track を early fail させる。
+
+#### 検査項目
+- `centerline` 点数が十分か
+- `track_width > 0` か
+- `start_line` が 2 点定義されているか
+- `forward_hint` が妥当か
+- 必須キーが全てあるか
+
+#### 完了条件
+- validation 成功 / 失敗が判定できる
+
+#### 依存
+- Task 2-2
+
+---
+
+### Task 2-4: 最近点計算 utility 実装
+
+#### 目的
+AI・race logic・off-track 判定で使う最近点計算を共通化する。
+
+#### 作業内容
+- point に対する centerline 最近点 index 計算
+- 最近点座標計算
+- point-to-centerline 距離計算
+
+#### 完了条件
+- 単純な centerline に対して正しい最近点が返る
+- 単体テストが通る
+
+#### 依存
+- Task 2-1
+
+---
+
+### Task 2-5: lookahead point 計算 utility 実装
+
+#### 目的
+AI controller が使う lookahead point を共通化する。
+
+#### 作業内容
+- 最近点から一定距離先を辿る
+- centerline 上の lookahead point を返す
+
+#### 完了条件
+- 与えた距離に対して妥当な lookahead point が返る
+- closed loop で動作する
+
+#### 依存
+- Task 2-4
+
+---
+
+### Task 2-6: start_line 交差判定 utility 実装
+
+#### 目的
+race_manager の lap 判定に使う線分交差処理を共通化する。
+
+#### 作業内容
+- 移動線分と start_line の交差判定
+- move_vec と forward_hint の整合判定補助
+
+#### 完了条件
+- 正方向交差と逆方向交差を区別できる
+- 単体テストが通る
+
+#### 依存
+- Task 2-1
+
+---
+
+### Task 2-7: sample track 作成
+
+#### 目的
+最低限の動作確認に使うトラックを用意する。
+
+#### 作業内容
+- 周回コース track 作成
+- 任意で八の字コース track 作成
+
+#### 完了条件
+- race_manager / renderer / ai_driver が共通利用できる track file がある
+
+#### 依存
+- Task 2-2
+
+---
+
+## 7. Phase 3: Vehicle Backend
+
+### Task 3-1: `vehicle_sim_node` skeleton 作成
+
+#### 目的
+internal vehicle backend の基本ノードを作る。
+
+#### 作業内容
+- node 起動
+- parameter 読み込み
+- `/carX/cmd_drive` subscribe
+- `/carX/odom` publisher 作成
+- timer loop 作成
+
+#### 完了条件
+- ノード起動可能
+- odom が publish される
+
+#### 依存
+- Task 1-1
+- Task 0-2
+
+---
+
+### Task 3-2: state 初期化実装
+
+#### 目的
+初期姿勢と初期状態を保持できるようにする。
+
+#### 作業内容
+- `initial_pose_x`
+- `initial_pose_y`
+- `initial_pose_yaw`
+- velocity 初期化
+- steering 初期化
+
+#### 完了条件
+- 起動時に初期姿勢で odom が出る
+
+#### 依存
+- Task 3-1
+
+---
+
+### Task 3-3: Kinematic Bicycle Model 実装
+
+#### 目的
+軽量な車両運動モデルを実装する。
+
+#### 状態変数
+- `x`
+- `y`
+- `yaw`
+- `velocity`
+
+#### 入力
+- `throttle_cmd`
+- `steering_cmd`
+
+#### 完了条件
+- throttle で加速できる
+- steering で旋回できる
+
+#### 依存
+- Task 3-2
+
+---
+
+### Task 3-4: 入力変換 / 飽和 / 速度制限実装
+
+#### 目的
+DriveCommand を物理量へ変換し、安全に扱う。
+
+#### 作業内容
+- `throttle_cmd -> acceleration`
+- `steering_cmd -> steering_angle`
+- `[-1, 1]` 飽和
+- `max_speed_mps` 制限
+- 後退許可
+
+#### 完了条件
+- 異常値でも破綻しない
+- 速度が上限を超えない
+
+#### 依存
+- Task 3-3
+
+---
+
+### Task 3-5: command timeout 実装
+
+#### 目的
+入力停止時に安全に中立へ戻す。
+
+#### 作業内容
+- `cmd_timeout_sec`
+- 最終受信時刻管理
+- timeout 時の中立入力化
+
+#### 完了条件
+- command 未受信で中立化される
+
+#### 依存
+- Task 3-1
+
+---
+
+### Task 3-6: odom publish 実装
+
+#### 目的
+車両状態を ROS 標準 message で publish する。
+
+#### 作業内容
+- `nav_msgs/Odometry` 作成
+- pose を `odom` frame で設定
+- twist を `carX/base_link` frame で設定
+
+#### 完了条件
+- `/carX/odom` が仕様通りに出る
+
+#### 依存
+- Task 3-3
+
+---
+
+### Task 3-7: TF broadcast 実装
+
+#### 目的
+車両 frame を TF で配信する。
+
+#### 作業内容
+- `odom -> carX/base_link` を broadcast
+- odom と同一状態・同一時刻で生成
+
+#### 完了条件
+- TF が RViz / tf_tools 等で確認できる
+- odom と矛盾しない
+
+#### 依存
+- Task 3-6
+
+---
+
+### Task 3-8: `/race/command` subscribe と RESET 対応
+
+#### 目的
+レースリセット時に車両状態を初期化できるようにする。
+
+#### 作業内容
+- `/race/command` subscribe
+- `RESET` を受信したら初期姿勢へ戻す
+- `START` / `STOP` は無視してよい
+
+#### 完了条件
+- RESET で位置・姿勢・速度・入力状態が初期化される
+
+#### 依存
+- Task 1-2
+- Task 3-2
+
+---
+
+### Task 3-9: internal class 分離
+
+#### 目的
+責務肥大化を防ぎ、将来拡張しやすくする。
+
+#### 想定分割
+- `VehicleDynamics`
+- `DriveCommandAdapter`
+- `OdometryPublisher`
+- `TfPublisher`
+
+#### 完了条件
+- 主要責務がクラス分離されている
+- 単一ファイルに全ロジックが密結合していない
+
+#### 依存
+- Task 3-3 ～ 3-8
+
+---
+
+### Task 3-10: vehicle_sim の基本テスト
+
+#### 目的
+backend の最低限の信頼性を確保する。
+
+#### テスト項目
+- 直進
+- 左右旋回
+- 後退
+- timeout
+- reset
+- speed clip
+
+#### 完了条件
+- 基本動作が一通り確認できる
+- テスト手順を docs に記載できる
+
+#### 依存
+- Task 3-8
+
+---
+
+## 8. Phase 4: Race Logic
+
+### Task 4-1: `race_manager_node` skeleton 作成
+
+#### 目的
+race logic の central node を作る。
+
+#### 作業内容
+- `/race/command` subscribe
+- `/carX/odom` subscribe
+- `/race/state` publisher
+- `/race/lap_event` publisher
+- `/race/vehicle_status` publisher
+
+#### 完了条件
+- `READY` 状態で起動できる
+
+#### 依存
+- Task 1-2 ～ 1-5
+
+---
+
+### Task 4-2: RaceState machine 実装
+
+#### 目的
+レース全体の状態遷移を作る。
+
+#### 状態
+- `READY`
+- `COUNTDOWN`
+- `RUNNING`
+- `FINISHED`
+- `STOPPED`
+
+#### 遷移
+- `START`
+- countdown timeout
+- `STOP`
+- `RESET`
+- finish 条件
+
+#### 完了条件
+- 状態遷移が仕様通りに動く
+
+#### 依存
+- Task 4-1
+
+---
+
+### Task 4-3: odom cache 実装
+
+#### 目的
+各車両の最新状態を race_manager 内で保持する。
+
+#### 作業内容
+- `vehicle_id` ごとの最新 odom をキャッシュ
+- `has_received_odom` を管理
+
+#### 完了条件
+- 複数車両を同時に追跡できる
+
+#### 依存
+- Task 4-1
+
+---
+
+### Task 4-4: elapsed_time 実装
+
+#### 目的
+レース時間を正しく管理する。
+
+#### 作業内容
+- `RUNNING` 開始時刻を保持
+- `elapsed_time` 計算
+- `STOPPED` / `FINISHED` で停止
+
+#### 完了条件
+- countdown を含めずに時間が増える
+
+#### 依存
+- Task 4-2
+
+---
+
+### Task 4-5: lap 判定実装
+
+#### 目的
+レースの中心機能である lap 判定を作る。
+
+#### 条件
+- start_line 交差
+- forward_hint 整合
+- cooldown 超過
+- `RUNNING`
+- `has_finished == false`
+- odom 受信済み
+
+#### 完了条件
+- 正方向でのみ lap_count が増える
+- 多重カウントしない
+
+#### 依存
+- Task 2-6
+- Task 4-3
+
+---
+
+### Task 4-6: lap timing 実装
+
+#### 目的
+各車両のラップ時間を計算する。
+
+#### 作業内容
+- `current_lap_time`
+- `last_lap_time`
+- `best_lap_time`
+- `total_elapsed_time`
+- `has_finished`
+
+#### 完了条件
+- ラップ成立時に正しく更新される
+
+#### 依存
+- Task 4-5
+
+---
+
+### Task 4-7: finish 判定実装
+
+#### 目的
+レース終了条件を管理する。
+
+#### 条件
+- 最初に `total_laps` を完了した車両が出た時点で `FINISHED`
+
+#### 完了条件
+- finish 条件で `RUNNING -> FINISHED` へ遷移する
+
+#### 依存
+- Task 4-6
+
+---
+
+### Task 4-8: off-track 判定実装
+
+#### 目的
+コース外判定を実装する。
+
+#### 作業内容
+- 最近点距離計算
+- `distance > track_width / 2` で off-track
+- `inside -> outside` で `off_track_count += 1`
+
+#### 完了条件
+- `is_off_track` と `off_track_count` が動作する
+
+#### 依存
+- Task 2-4
+- Task 4-3
+
+---
+
+### Task 4-9: `VehicleRaceStatus` publish 実装
+
+#### 目的
+renderer が継続表示に使う status を出力する。
+
+#### 作業内容
+- 1車両1メッセージ publish
+- 同一 topic に複数車両分を流す
+- `vehicle_id` を付与
+
+#### 完了条件
+- `/race/vehicle_status` に status が流れる
+
+#### 依存
+- Task 4-6
+- Task 4-8
+
+---
+
+### Task 4-10: `LapEvent` publish 実装
+
+#### 目的
+ラップ成立時イベントを通知する。
+
+#### 作業内容
+- lap 成立時のみ `LapEvent` publish
+- `lap_time`, `best_lap_time`, `has_finished` を含める
+
+#### 完了条件
+- ラップ成立時のみイベントが発行される
+
+#### 依存
+- Task 4-6
+
+---
+
+### Task 4-11: RaceState publish 実装
+
+#### 目的
+AI や renderer が全体状態を参照できるようにする。
+
+#### 作業内容
+- 毎周期 `/race/state` publish
+- `race_status`, `elapsed_time`, `total_laps` を設定
+
+#### 完了条件
+- 全状態で `/race/state` が確認できる
+
+#### 依存
+- Task 4-2
+- Task 4-4
+
+---
+
+### Task 4-12: race_manager の基本テスト
+
+#### 目的
+state machine と race logic の妥当性を確認する。
+
+#### テスト項目
+- START
+- COUNTDOWN
+- RUNNING
+- STOP
+- RESET
+- lap 成立
+- finish
+- off-track
+
+#### 完了条件
+- 主要状態遷移とイベントが確認できる
+
+#### 依存
+- Task 4-11
+
+---
+
+### Task 4-13: minimal scenario file 導入
+#### 目的
+初期姿勢や controller 割り当てのベタ書きを避ける。
+#### 作業内容
+YAML による最小 scenario を定義する。
+- total_laps
+- vehicle list
+- initial poses
+- controller_type
+- input source
+#### 完了条件
+1台以上の vehicle 設定を file から与えられる
+#### 依存
+- Task 4-11
+
+
+---
+
+## 9. Phase 5: Input Nodes
+
+### Task 5-1: `gamepad_input_node` skeleton 作成
+
+#### 目的
+manual input source を作る。
+
+#### 作業内容
+- node 作成
+- joystick 入力購読
+- `/carX/cmd_drive` publisher 作成
+
+#### 完了条件
+- node が起動できる
+
+#### 依存
+- Task 1-1
+
+---
+
+### Task 5-2: gamepad 軸マッピング実装
+
+#### 目的
+PS4 controller を想定した操作入力を実装する。
+
+#### モード
+- `trigger_steering`
+- `right_stick_throttle`
+
+#### 完了条件
+- steering / throttle が正しく `DriveCommand` に変換される
+
+#### 依存
+- Task 5-1
+
+---
+
+### Task 5-3: deadzone / invert / normalize 実装
+
+#### 目的
+実用的な入力処理を行う。
+
+#### 作業内容
+- deadzone 適用
+- 軸反転設定
+- `[-1, 1]` 正規化
+
+#### 完了条件
+- ニュートラルで勝手に動かない
+
+#### 依存
+- Task 5-2
+
+---
+
+### Task 5-4: `keyboard_input_node` 実装
+
+#### 目的
+fallback / debug 用 manual input source を作る。
+
+#### 作業内容
+- キー入力読み取り
+- `/carX/cmd_drive` publish
+
+#### 完了条件
+- キーボードで車両が動く
+
+#### 依存
+- Task 1-1
+
+---
+
+### Task 5-5: `race_command_input_node` 実装
+
+#### 目的
+レース操作を独立した入力ノードとして提供する。
+
+#### 作業内容
+- START
+- STOP
+- RESET
+を `RaceCommand` として publish
+
+#### 完了条件
+- `/race/command` を手動送信できる
+
+#### 依存
+- Task 1-2
+
+---
+
+### Task 5-6: input source 切替確認
+
+#### 目的
+manual source の競合を防ぐ。
+
+#### 作業内容
+- gamepad / keyboard が同時に同一車両へ送られないよう確認
+- launch / config で片方だけ有効にする
+
+#### 完了条件
+- 1車両につき 1 manual source で動作する
+
+#### 依存
+- Task 5-3
+- Task 5-4
+
+---
+
+## 10. Phase 6: Renderer
+
+### Task 6-1: `renderer_node` skeleton 作成
+
+#### 目的
+初版可視化ノードの枠組みを作る。
+
+#### 作業内容
+- node 作成
+- 描画ループ作成
+- topic subscriber 作成
+
+#### 完了条件
+- 空画面でも起動する
+
+#### 依存
+- Task 1-3 ～ 1-5
+
+---
+
+### Task 6-2: track 描画実装
+
+#### 目的
+logical track を表示する。
+
+#### 作業内容
+- centerline 描画
+- track_width による corridor 表示
+- start_line 表示
+
+#### 完了条件
+- sample track が画面に表示される
+
+#### 依存
+- Task 2-7
+
+---
+
+### Task 6-3: 車両描画実装
+
+#### 目的
+複数車両を可視化する。
+
+#### 作業内容
+- `/carX/odom` を使った位置表示
+- 向き表示
+- `vehicle_id` 表示
+
+#### 完了条件
+- 複数車両が区別可能に描画される
+
+#### 依存
+- Task 3-6
+- Task 3-7
+
+---
+
+### Task 6-4: HUD 表示実装
+
+#### 目的
+レース状態を画面上で確認できるようにする。
+
+#### 表示項目
+- race_state
+- elapsed_time
+- lap_count
+- current_lap_time
+- best_lap_time
+- has_finished
+- is_off_track
+- off_track_count
+
+#### 完了条件
+- `/race/state` と `/race/vehicle_status` を画面で確認できる
+
+#### 依存
+- Task 4-9
+- Task 4-11
+
+---
+
+### Task 6-5: LapEvent 一時表示実装
+
+#### 目的
+イベント通知を見やすくする。
+
+#### 表示内容
+- LAP 更新
+- BEST LAP
+- FINISHED
+
+#### 完了条件
+- `LapEvent` 発生時に一時表示される
+
+#### 依存
+- Task 4-10
+
+---
+
+### Task 6-6: renderer の表示責務確認
+
+#### 目的
+renderer に判定ロジックが混入していないことを確認する。
+
+#### 確認項目
+- lap 判定をしていない
+- off-track 判定をしていない
+- `VehicleRaceStatus` を真としている
+
+#### 完了条件
+- renderer が表示専用に保たれている
+
+#### 依存
+- Task 6-5
+
+---
+
+## 11. Phase 7: AI Driver
+
+### Task 7-1: `ai_driver_node` skeleton 作成
+
+#### 目的
+AI 車両制御ノードの枠組みを作る。
+
+#### 作業内容
+- `/carX/odom` subscribe
+- `/race/state` subscribe
+- `/carX/cmd_drive` publisher 作成
+
+#### 完了条件
+- node が起動する
+- `RUNNING` 以外では中立入力を出せる
+
+#### 依存
+- Task 1-1
+- Task 1-3
+
+---
+
+### Task 7-2: target point selection 実装
+
+#### 目的
+track から制御目標点を選べるようにする。
+
+#### 作業内容
+- centerline 最近点計算
+- lookahead point 計算
+- 毎周期の再計算
+
+#### 完了条件
+- target point が安定して選ばれる
+
+#### 依存
+- Task 2-5
+- Task 7-1
+
+---
+
+### Task 7-3: Pure Pursuit controller 実装
+
+#### 目的
+初版の主 AI controller を実装する。
+
+#### 作業内容
+- lookahead point に基づく steering 計算
+- `DriveCommand` の steering 側生成
+
+#### 完了条件
+- `controller_type = pure_pursuit` で動作する
+
+#### 依存
+- Task 7-2
+
+---
+
+### Task 7-4: speed controller 実装
+
+#### 目的
+縦方向制御を実装する。
+
+#### 作業内容
+- `base_target_speed_mps`
+- `speed_kp`
+- steering 量に応じた減速
+
+#### 完了条件
+- straight で加速し、曲がるとき少し減速する
+
+#### 依存
+- Task 7-3
+
+---
+
+### Task 7-5: `pid_heading` controller 実装
+
+#### 目的
+比較・学習用途の第二 controller を実装する。
+
+#### 作業内容
+- heading error 計算
+- PID による steering 計算
+- `heading_kp`, `heading_ki`, `heading_kd`
+
+#### 完了条件
+- `controller_type = pid_heading` で動作する
+
+#### 依存
+- Task 7-2
+
+---
+
+### Task 7-6: controller 切替機構実装
+
+#### 目的
+controller を strategy / plugin 的に切り替えられるようにする。
+
+#### 作業内容
+- `ControllerBase`
+- `PurePursuitController`
+- `PidHeadingController`
+- `controller_type` parameter
+
+#### 完了条件
+- config だけで controller を切り替えられる
+
+#### 依存
+- Task 7-3
+- Task 7-5
+
+---
+
+### Task 7-7: race state 連動確認
+
+#### 目的
+AI がレース状態に応じて動作することを確認する。
+
+#### 期待動作
+- `READY`: 中立入力
+- `COUNTDOWN`: 中立入力
+- `RUNNING`: 制御開始
+- `FINISHED`: 中立入力
+- `STOPPED`: 中立入力
+
+#### 完了条件
+- 全状態で期待通りに動く
+
+#### 依存
+- Task 7-6
+
+---
+
+### Task 7-8: AI integration test
+
+#### 目的
+AI 車両の初版成立性を確認する。
+
+#### テスト項目
+- `pure_pursuit` で周回可能か
+- `pid_heading` で比較可能か
+- off-track から復帰しやすいか
+- `RUNNING` 以外で止まるか
+
+#### 完了条件
+- 初版 acceptance の AI 要件を満たす
+
+#### 依存
+- Task 7-7
+
+---
+
+## 12. Phase 8: Bringup / Scenario
+
+### Task 8-1: `race.launch.py` 作成
+
+#### 目的
+初版システムを 1コマンドで起動できるようにする。
+
+#### 起動対象
+- `vehicle_sim_node`
+- `race_manager_node`
+- `renderer_node`
+- input nodes
+- `ai_driver_node`
+
+#### 完了条件
+- launch でシステムが立ち上がる
+
+#### 依存
+- Phase 3 ～ 7
+
+---
+
+### Task 8-2: config / scenario file 作成
+
+#### 目的
+runtime 条件を file ベースで切り替えられるようにする。
+
+#### 内容
+- race settings
+- vehicle settings
+- initial poses
+- controller assignment
+- input mode
+
+#### 完了条件
+- config を変えることで台数・controller・初期位置を変更できる
+
+#### 依存
+- Task 8-1
+
+---
+
+### Task 8-3: multi-vehicle 起動確認
+
+#### 目的
+vehicle namespace 設計が多車両で成立することを確認する。
+
+#### 例
+- `car1`: manual
+- `car2`: pure_pursuit
+- `car3`: pid_heading（任意）
+
+#### 完了条件
+- 複数車両が namespace 衝突なく動く
+
+#### 依存
+- Task 8-2
+
+---
+
+## 13. Phase 9: Test / Quality
+
+### Task 9-1: acceptance checklist 作成
+
+#### 目的
+手動確認手順を明文化する。
+
+#### 内容
+- 起動
+- command
+- lap
+- finish
+- off-track
+- renderer
+- AI
+
+#### 完了条件
+- pass/fail を判断できる checklist がある
+
+#### 依存
+- Phase 8
+
+---
+
+### Task 9-2: logging / debug 出力整理
+
+#### 目的
+状態遷移や lap 判定の追跡をしやすくする。
+
+#### 内容
+- race state transition log
+- lap detection log
+- reset log
+- off-track log
+
+#### 完了条件
+- 問題発生時にログで追える
+
+#### 依存
+- Task 4-12
+
+---
+
+### Task 9-3: docs 更新
+
+#### 目的
+使い方と開発状況を文書化する。
+
+#### 内容
+- README 更新
+- 起動手順
+- config 説明
+- track file 説明
+- controller 説明
+
+#### 完了条件
+- docs を読めば起動・開発ができる
+
+#### 依存
+- Phase 8
+
+---
+
+## 14. Phase 10: Future Extensions (Optional)
+
+### Task 10-1: `race_map` の OpenDRIVE 対応
+
+#### 目的
+外部地図資産を取り込む準備をする。
+
+#### 作業内容
+- OpenDRIVE parse
+- normalization
+- logical track 生成支援
+
+#### 完了条件
+- OpenDRIVE を読み込める基礎ができる
+
+---
+
+### Task 10-2: `race_carla_bridge` skeleton
+
+#### 目的
+CARLA backend 差し替えのための入り口を作る。
+
+#### 作業内容
+- `/carX/cmd_drive` 受け取り
+- CARLA control への変換
+- CARLA state → `/carX/odom`
+
+#### 完了条件
+- bridge package が build 可能
+- skeleton が存在する
+
+---
+
+### Task 10-3: sensor topic 予約対応
+
+#### 目的
+将来の sensor integration に備える。
+
+#### 想定 topic
+- `/carX/points_raw`
+- `/carX/radar`
+- `/carX/camera/image_raw`
+- `/carX/camera/camera_info`
+
+#### 完了条件
+- architecture / docs 上で sensor extension を説明できる
+
+---
+
+### Task 10-4: Stanley / MPC controller 追加
+
+#### 目的
+controller 比較を拡張する。
+
+#### 完了条件
+- `controller_type` を増やせる構造になっている
+- 実装に着手できる設計になっている
+
+---
+
+## 15. 最初に切るべき GitHub Issues
+最初の 11 個に絞るなら、以下の順で切る。
+1. workspace / package skeleton
+2. custom messages
+3. TrackModel
+4. track loader
+5. geometry utilities
+6. sample track
+7. vehicle_sim skeleton
+8. bicycle model
+9. odom + TF
+10. race_manager skeleton
+11. minimal scenario file
+
+
+---
+
+## 16. マイルストーン案
+### Milestone 1: 車が動く
+- `race_interfaces`
+- `race_track`
+- `vehicle_sim_node`
+- `DriveCommand -> Odometry / TF` が成立する
+
+### Milestone 2: レース状態が成立する
+- `race_manager_node`
+- `race_command_input_node`
+- `READY / COUNTDOWN / RUNNING / STOPPED / FINISHED` が遷移する
+- lap / off-track が成立する
+
+### Milestone 3: 状態が観測できる
+- `renderer_node`
+- track / 車両位置 / race state / lap 情報が見える
+
+### Milestone 4: 手動操作できる
+- `gamepad_input_node`
+- `keyboard_input_node`
+
+### Milestone 5: AI で周回できる
+- `ai_driver_node`
+- `pure_pursuit`
+- AI 車両が 1 周以上継続走行できる
+
+### Milestone 6: 比較できる
+- `pid_heading`
+- multi-vehicle comparison
+
+### Milestone 7: 将来拡張の入口
+- `race_map`
+- `race_carla_bridge`
+
+
+---
+
+## 17. 実装時の注意
+
+### 17.1 今やらないことを守る
+- OpenDRIVE を今すぐ読まない
+- Track.msg を作らない
+- track provider node を作らない
+- renderer にロジックを入れない
+- race_manager に表示都合を入れない
+- AI node に lap 判定を入れない
+
+### 17.2 今やるべきことに集中する
+- interface を固定する
+- track library を作る
+- internal backend で成立させる
+- race logic を固める
+
+### 17.3 設計を崩さない
+- vehicle namespace を守る
+- `/carX/cmd_drive` と `/carX/odom` を守る
+- `/race/...` を全体情報に限定する
+- simulator-specific code は backend / bridge に隔離する
+
+---
+
+## 18. 本書の位置づけ
+
+本書は、以下の開発作業の基準となる。
+
+- GitHub Issue 作成
+- Project board 作成
+- 実装順の管理
+- milestone 管理
+- review 時の作業単位確認
+
+本書により、仕様と実装の間を埋めることを目的とする。
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,616 @@
+# ROS2 Race Simulator
+## Requirements Definition
+
+---
+
+## 1. 文書の目的
+
+本書は、ROS2 上で動作するレースシミュレーション環境の開発に向けて、プロジェクトの目的、対象範囲、要求事項、設計上の前提、および完成条件を整理するための要件定義書である。
+
+本プロジェクトは単なるゲーム開発ではなく、以下を主目的とする。
+
+- ROS2 の理解を深めること
+- node / topic / message / TF / Odometry の設計理解
+- simulation time / wall time の扱いの理解
+- race logic の状態設計の理解
+- vehicle control の理解
+- 将来的な CARLA 連携や外部地図資産利用を見据えた拡張可能な構造を作ること
+
+---
+
+## 2. プロジェクトの目的
+
+### 2.1 主目的
+
+本プロジェクトの主目的は、ROS2 を用いた **軽量なレースシミュレーション環境** を構築し、その実装を通して ROS2 システム設計を学ぶことである。
+
+このプロジェクトは、以下を学習・検証するための土台とする。
+
+- ROS2 のノード分割
+- topic 設計
+- custom message 設計
+- `nav_msgs/Odometry` の使い方
+- TF の使い方
+- 座標系設計
+- `use_sim_time` の扱い
+- RaceState / Lap 判定ロジック
+- controller（Pure Pursuit / PID heading）の比較
+- 将来の simulator-independent な構造設計
+
+### 2.2 将来的な拡張目標
+
+本システムは、初版では内部の軽量シミュレータを用いるが、長期的には以下へ拡張することを想定する。
+
+- CARLA を用いた高忠実度シミュレーション
+- LiDAR / Radar / Camera の利用
+- perception / planning / control の統合
+- OpenDRIVE を主とした外部地図資産の利用
+- 競技・公開地図データ（例: つくばチャレンジ等）の取り込み
+- simulator backend の差し替え
+- controller の比較研究（Pure Pursuit / PID / Stanley / MPC）
+
+---
+
+## 3. スコープ
+
+### 3.1 初版で実施する範囲
+
+初版では、以下を実装対象とする。
+
+#### レース環境
+- 2D の周回トラックを扱う
+- track file によりレース論理コースを定義する
+- start_line, centerline, track_width, forward_hint を扱う
+
+#### 車両
+- 複数車両に対応する
+- 手動操作車両を少なくとも 1 台持つ
+- AI 操作車両を少なくとも 1 台持つ
+- 各車両は namespace により分離される
+
+#### 操作
+- gamepad による手動入力
+- keyboard による fallback 入力
+- race command 入力（START / STOP / RESET）
+- AI controller による自動入力
+
+#### AI
+- Pure Pursuit による追従走行
+- PID on heading による比較用 controller
+- controller 切替可能構造
+
+#### レース機能
+- READY / COUNTDOWN / RUNNING / FINISHED / STOPPED の状態管理
+- lap 計測
+- best lap 計測
+- off-track 判定
+- stop / reset 対応
+
+#### 可視化
+- 軽量な独自 2D renderer
+- 車両位置、向き、race state、lap 情報の表示
+- LapEvent の簡易表示
+
+#### シミュレーション
+- Kinematic Bicycle Model による軽量な車両運動
+- 最高速度制限
+- command timeout
+- reset 時の初期姿勢復帰
+
+---
+
+### 3.2 初版では実施しない範囲
+
+以下は初版では対象外とする。
+
+- 3D 可視化
+- Unity 連携
+- Unreal Engine 連携
+- 実センサシミュレーション
+- LiDAR / Radar / Camera topic の生成
+- perception ノード
+- planning ノード
+- localization ノード
+- dynamic obstacle
+- vehicle-to-vehicle interaction
+- overtaking
+- collision 判定
+- 高忠実度 vehicle dynamics
+- MPC の実装
+- OpenDRIVE 直接読み込み
+- 外部地図資産の本格利用
+- track の topic 配信
+- track provider node
+- scenario editor
+- GUI からの複雑な操作
+
+---
+
+### 3.2.1 初版で禁止する拡張
+以下は、将来構想として文書に存在していても、初版では実装に着手してはならない。
+- collision 判定
+- overtaking
+- vehicle-to-vehicle interaction
+- dynamic obstacle
+- 高忠実度 vehicle dynamics
+- OpenDRIVE 読み込み
+- sensor topic 生成
+- Track.msg の導入
+- track provider node の導入
+- 複雑な GUI 操作系
+- renderer の高機能化
+- controller plugin 機構の過剰実装
+
+これらは初版 acceptance criteria を満たした後にのみ再検討する。
+
+---
+
+### 3.3 初版実装方針
+初版実装では、ROS2 システム設計の理解と、軽量な internal backend による最小レース成立を最優先とする。
+
+以下を初版実装の原則とする。
+- 最初から将来拡張用の過剰な抽象化を行わない
+- plugin 機構や汎用 factory は、初版で必要になるまで導入しない
+- internal backend で成立する最小構成を優先する
+- 各フェーズで build / run / inspect 可能な状態を維持する
+- 「将来必要かもしれない」機能は、明確な使用箇所が出るまで実装しない
+
+初版では、設計上の拡張可能性は保持するが、未使用の拡張ポイントを実装しすぎないこと。
+
+---
+
+## 4. 想定ユーザと利用シナリオ
+
+### 4.1 想定ユーザ
+- プロジェクト開発者本人
+- ROS2 学習者
+- 将来的には controller の比較研究をしたい開発者
+- 将来 CARLA や OpenDRIVE に接続したい開発者
+
+### 4.2 主な利用シナリオ
+
+#### シナリオ 1: ROS2 学習
+- 手動車両を gamepad で操作する
+- `cmd_drive` / `odom` / `RaceState` / `VehicleRaceStatus` の流れを確認する
+- TF と Odometry の関係を学ぶ
+
+#### シナリオ 2: AI 比較
+- `car1` を手動
+- `car2` を Pure Pursuit
+- `car3` を PID heading
+として比較する
+
+#### シナリオ 3: race logic 検証
+- start / stop / reset を試す
+- lap 判定を確認する
+- off-track 判定を確認する
+
+#### シナリオ 4: 将来拡張
+- internal backend を CARLA backend に差し替える
+- OpenDRIVE から map adaptation を行い track を生成する
+- sensor topic を追加する
+
+---
+
+## 5. 機能要求
+
+### 5.1 車両制御要求
+
+#### 5.1.1 DriveCommand
+システムは車両制御入力として `DriveCommand` を扱うこと。
+
+- throttle_cmd
+- steering_cmd
+
+両者の値域は以下とする。
+
+- `throttle_cmd ∈ [-1.0, 1.0]`
+- `steering_cmd ∈ [-1.0, 1.0]`
+
+#### 5.1.2 車両ごとの入力源
+各車両の `DriveCommand` 生成元は以下のいずれかである。
+
+- gamepad_input_node
+- keyboard_input_node
+- ai_driver_node
+
+同一車両に対し、複数の manual input source を同時に有効化してはならない。
+
+---
+
+### 5.2 車両状態要求
+
+各車両は以下の状態を持つこと。
+
+- position
+- yaw
+- velocity
+
+その状態は ROS 標準の `nav_msgs/Odometry` で publish されること。
+
+#### 5.2.1 frame
+- `header.frame_id = "odom"`
+- `child_frame_id = "carX/base_link"`
+
+#### 5.2.2 TF
+各車両は `odom -> carX/base_link` を broadcast すること。
+
+---
+
+### 5.3 race command 要求
+
+システムはレース操作として以下を扱うこと。
+
+- START
+- STOP
+- RESET
+
+これらは独自 message `RaceCommand` で扱う。
+
+#### 5.3.1 START
+- `READY -> COUNTDOWN` の遷移開始
+
+#### 5.3.2 STOP
+- `COUNTDOWN` または `RUNNING` 中のレースを停止
+- `STOPPED` に遷移
+
+#### 5.3.3 RESET
+- race state の初期化
+- lap 情報の初期化
+- vehicle_sim の初期姿勢復帰
+
+---
+
+### 5.4 race state 要求
+
+システムはレース全体の状態として以下を扱うこと。
+
+- READY
+- COUNTDOWN
+- RUNNING
+- FINISHED
+- STOPPED
+
+#### 5.4.1 state 遷移
+- `READY --START--> COUNTDOWN`
+- `COUNTDOWN --timeout--> RUNNING`
+- `RUNNING --finish--> FINISHED`
+- `COUNTDOWN/RUNNING --STOP--> STOPPED`
+- `STOPPED/FINISHED --RESET--> READY`
+
+#### 5.4.2 elapsed_time
+- `RUNNING` 開始時から加算
+- `COUNTDOWN` は含めない
+- `FINISHED` / `STOPPED` で停止
+
+---
+
+### 5.5 ラップ要求
+
+#### 5.5.1 ラップ成立条件
+ラップは以下を全て満たしたときのみ成立する。
+
+1. 車両移動線分が `start_line` を横切る
+2. `forward_hint` と進行方向が整合する
+3. `lap_cooldown_sec` 以上経過している
+4. `race_status == RUNNING`
+5. `has_finished == false`
+6. odom を受信済みである
+
+#### 5.5.2 ラップ情報
+各車両は以下を管理する。
+
+- lap_count
+- current_lap_time
+- last_lap_time
+- best_lap_time
+- total_elapsed_time
+- has_finished
+
+#### 5.5.3 イベント
+ラップ成立時には `LapEvent` を publish する。
+
+---
+
+### 5.6 off-track 要求
+
+#### 5.6.1 判定
+車両位置と centerline の最近点距離が `track_width / 2` を超えた場合、off-track とみなす。
+
+#### 5.6.2 状態
+各車両は以下を管理する。
+
+- `is_off_track`
+- `off_track_count`
+
+#### 5.6.3 カウント条件
+`off_track_count` は `inside -> outside` の遷移時のみ加算する。
+
+#### 5.6.4 初版の扱い
+初版では off-track しても走行は継続する。失格・停止・ペナルティは与えない。
+
+---
+
+### 5.7 track 要求
+
+track は YAML 形式の file で定義する。
+
+最低限必要な項目は以下。
+
+- track_name
+- centerline
+- track_width
+- start_line
+- forward_hint
+
+#### 5.7.1 centerline
+- 2D waypoint 列
+- 等間隔不要
+- sparse すぎる定義は禁止
+
+#### 5.7.2 start_line
+- 2 点で定義される線分
+
+#### 5.7.3 forward_hint
+- intended travel direction を表すベクトル
+
+#### 5.7.4 track_width
+- 固定幅
+
+---
+
+### 5.8 map / track / scenario 要求
+
+本システムは以下を分離して扱うこと。
+
+#### 5.8.1 Map
+- 外部環境地図
+- 例: OpenDRIVE
+- `race_map` が扱う
+
+#### 5.8.2 Track
+- レース論理コース
+- centerline / start_line / forward_hint / track_width
+- `race_track` が扱う
+
+#### 5.8.3 Scenario
+- 実行条件
+- 初期姿勢
+- controller割り当て
+- race settings
+
+---
+
+### 5.9 AI 要求
+
+#### 5.9.1 入力
+AI driver は以下を入力とする。
+
+- `/carX/odom`
+- `/race/state`
+- track file（`race_track` ライブラリ経由）
+
+#### 5.9.2 出力
+- `/carX/cmd_drive`
+
+#### 5.9.3 controller
+初版で扱う controller は以下。
+
+- `pure_pursuit`
+- `pid_heading`
+
+#### 5.9.4 挙動
+- `RUNNING` のときのみ制御
+- それ以外は中立入力を出す
+
+#### 5.9.5 target point
+- centerline 最近点を毎周期取り直す
+- lookahead point を用いる
+
+---
+
+### 5.10 renderer 要求
+
+#### 5.10.1 役割
+renderer は初版における軽量なデバッグ・観測用 frontend であり、表示専用とする。
+renderer は race logic を持たず、見た目の完成度や演出性は初版の目的に含めない。
+
+
+#### 5.10.2 表示内容
+- centerline
+- track_width を持ったコース
+- start_line
+- 各車両の位置・向き
+- race state
+- elapsed_time
+- lap 情報
+- off-track 状態
+
+#### 5.10.3 入力
+- `/carX/odom`
+- `/race/state`
+- `/race/vehicle_status`
+- `/race/lap_event`
+- track file
+
+#### 5.10.4 継続表示の真実のソース
+- `VehicleRaceStatus`
+
+#### 5.10.5 イベント表示
+- `LapEvent` は一時表示・通知用
+
+---
+
+## 6. 非機能要求
+
+### 6.1 拡張性
+システムは以下に拡張可能であること。
+
+- simulator backend 差し替え
+- CARLA 連携
+- external map asset 読み込み
+- sensor topic 追加
+- controller 追加
+
+### 6.2 simulator-independent
+以下は simulator backend 非依存であること。
+
+- race_manager
+- ai_driver
+- custom messages
+- track / scenario の概念
+- race command / race state
+
+### 6.3 可読性
+仕様書と実装は、README や docs に転用できる程度に整理されていること。
+
+### 6.4 再利用性
+track は topic ではなく file + shared library で扱うこと。
+
+### 6.5 テスト容易性
+実装は段階的に build / run / inspect 可能であること。
+
+### 6.6 時間源の一貫性
+全ノードの時間計算は ROS clock を唯一の正とすること。
+- lap timing
+- countdown
+- cooldown
+- elapsed_time
+はすべて ROS time に基づいて計算する。
+wall time や独自 clock を race logic に混在させてはならない。
+
+### 6.7 責務境界の維持
+初版実装では以下の責務境界を崩してはならない。
+- vehicle backend は車両運動と車両状態 publish に限定する
+- race_manager はレース進行判定と状態更新に限定する
+- ai_driver は制御入力生成に限定する
+- renderer は表示専用とする
+
+---
+
+## 7. 外部地図資産要求
+
+### 7.1 主形式
+外部地図資産の主形式は OpenDRIVE を第一候補とする。
+
+### 7.2 位置づけ
+OpenDRIVE は physical/environment map であり、logical race track とは分離する。
+
+### 7.3 map adaptation
+将来、OpenDRIVE から以下を抽出または定義できるようにする。
+
+- centerline
+- start_line
+- forward_hint
+- track_width
+- lane 関連情報
+
+### 7.4 前提
+外部地図資産は、そのまま race logic 用入力として使えるとは限らない。  
+必要に応じて `race_map` による読み込み・正規化・変換を行う。
+
+---
+
+## 8. 完成条件（Acceptance Criteria）
+
+### 8.1 システム起動
+- workspace build 成功
+- launch でシステム起動可能
+
+### 8.2 車両状態
+- `/carX/odom` が publish される
+- `odom -> carX/base_link` が broadcast される
+
+### 8.3 race logic
+- START / STOP / RESET が動作する
+- RaceState が正しく遷移する
+- lap 判定が成立する
+- best lap が更新される
+
+### 8.4 off-track
+- `is_off_track` と `off_track_count` が動く
+
+### 8.5 track
+- YAML track file が読める
+- validation が効く
+
+### 8.6 AI
+- Pure Pursuit で周回可能
+- PID heading が controller として切り替え可能
+
+### 8.7 renderer
+- 車両位置と race 状態が可視化できる
+
+---
+
+## 9. 実装順の要求
+
+実装は以下の順で進めること。
+
+1. `race_interfaces`
+2. `race_track`
+3. `vehicle_sim_node`
+4. `race_manager_node`
+5. `gamepad_input_node` / `keyboard_input_node` / `race_command_input_node`
+6. `renderer_node`
+7. `ai_driver_node`
+
+各段階で、動作確認可能な最小システムを保つこと。
+
+---
+
+## 10. パッケージ構成要求
+
+想定パッケージ構成
+
+- `race_interfaces`
+- `race_track`
+- `race_map`
+- `race_vehicle`
+- `race_ai`
+- `race_manager`
+- `race_renderer`
+- `race_input`
+- `race_bringup`
+- `race_carla_bridge`
+
+---
+
+## 11. 設計上の重要な前提
+
+- `vehicle_sim_node` は初版の internal backend である
+- 将来は `race_carla_bridge` に置換可能である
+- renderer は暫定 frontend である
+- simulator 依存コードは bridge に隔離する
+- controller は `/carX/cmd_drive` に統一する
+- vehicle state は `/carX/odom` に統一する
+- `vehicle_id` と namespace と frame 名は一致させる
+
+---
+
+## 12. 本要件定義の位置づけ
+
+本書は、以下の文書の上流に位置する。
+
+- 仕様書
+- アーキテクチャ設計
+- 実装タスク分解
+- GitHub Issues
+
+本書で定めた要求を基準として、以降の設計と実装を行う。
+
+---
+
+## 初版開発ポリシー
+本プロジェクトの初版では、「軽量な internal backend により、ROS2 システム設計を成立させること」を最優先とする。
+
+そのため、以下を厳守する。
+- 動く最小構成を優先する
+- 各段階で build / run / inspect 可能な状態を維持する
+- 将来拡張のための過剰実装を行わない
+- 未使用の抽象層や plugin 機構を先行導入しない
+- renderer の高機能化を優先しない
+- race logic / vehicle dynamics / controller / visualization の責務境界を崩さない
+- 初版 acceptance criteria を満たすまで、将来機能には着手しない
+
+

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,971 @@
+# ROS2 Race Simulator
+## System Specification v1.3
+
+---
+
+## 1. 文書の目的
+
+本書は、ROS2 Race Simulator のシステム仕様を定義する文書である。  
+本システムは、ROS2 の学習、自動運転アルゴリズムの比較、将来的な CARLA 連携を見据えた simulator-independent な実験基盤として設計される。
+
+本書は、以下を明確にすることを目的とする。
+
+- システム全体構造
+- ノード構成
+- トピックとメッセージ
+- レースロジック
+- トラック定義
+- マップ／トラック／シナリオの責務分離
+- 初版 backend と将来 backend の関係
+- 実装時に守るべき設計制約
+
+---
+
+## 2. システム概要
+
+本システムは、複数車両が同一トラック上で走行する ROS2 ベースのレースシミュレータである。  
+各車両は手動操作または AI 操作を受け、レース全体は専用の race manager によって制御される。
+
+初版では以下を提供する。
+
+- 軽量な internal vehicle backend
+- 手動操作車両
+- AI 操作車両
+- レース状態管理
+- ラップ計測
+- コースアウト判定
+- 軽量 2D renderer
+
+将来的には以下を想定する。
+
+- CARLA backend
+- OpenDRIVE を主とする外部地図資産利用
+- LiDAR / Radar / Camera
+- perception / planning / control への拡張
+
+---
+## 2.5 Initial Success Criteria
+初版の成功は、以下の最小条件を満たすこととする。
+
+1. 1台の車両で `DriveCommand -> vehicle_sim -> Odometry / TF` が成立する
+2. `RaceCommand` により `READY / COUNTDOWN / RUNNING / STOPPED / FINISHED` が遷移する
+3. lap 判定と off-track 判定が動作する
+4. renderer で track / 車両位置 / race state / lap 情報を確認できる
+5. Pure Pursuit により AI 車両が 1 周以上継続走行できる
+
+上記を満たすまでは、将来拡張機能の追加を行わない。
+
+---
+
+## 3. システム全体構造
+
+本システムは以下のレイヤ構造で構成される。
+
+~~~text
+Controller Layer
+    │
+    ▼
+Drive Command Interface
+    │
+    ▼
+Vehicle Simulation Backend
+    │
+    ▼
+Vehicle State Interface
+    │
+    ▼
+Race Logic Layer
+    │
+    ▼
+Visualization Layer
+~~~
+
+### 3.1 Controller Layer
+
+各車両の入力源を担当する。
+
+例:
+- `gamepad_input_node`
+- `keyboard_input_node`
+- `ai_driver_node`
+
+これらはすべて `DriveCommand` を生成する。
+
+### 3.2 Vehicle Simulation Backend
+
+車両運動を計算し、車両状態を ROS topic に変換して publish する。
+
+初版:
+- `vehicle_sim_node`
+
+将来:
+- `race_carla_bridge` + `CARLA`
+
+### 3.3 Race Logic Layer
+
+レース進行を管理する。
+
+担当:
+- RaceState 管理
+- ラップ判定
+- タイム計測
+- コースアウト判定
+- 車両別レース状態の生成
+
+### 3.4 Visualization Layer
+
+人間がレース状態を観測するための表示層。
+
+初版:
+- `renderer_node`
+
+将来:
+- simulator-native visualization
+- CARLA 側可視化
+- そのほか外部 frontend
+
+---
+
+## 4. ノード構成
+
+本システムで想定する初版ノードは以下の通り。
+
+- `vehicle_sim_node`
+- `ai_driver_node`
+- `race_manager_node`
+- `renderer_node`
+- `gamepad_input_node`
+- `keyboard_input_node`
+- `race_command_input_node`
+
+将来追加想定:
+- `race_carla_bridge`
+
+---
+
+## 5. Vehicle Namespace Policy
+
+各車両は固有の namespace を持つ。
+
+例:
+- `/car1`
+- `/car2`
+- `/car3`
+
+### 5.1 車両固有 topic
+
+各車両 namespace 配下に、以下の車両固有 topic を配置する。
+
+- `/carX/cmd_drive`
+- `/carX/odom`
+
+### 5.2 車両固有 frame
+
+各車両の frame 名は `vehicle_id` を接頭辞に持つ。
+
+例:
+- `car1/base_link`
+- `car2/base_link`
+
+### 5.3 命名制約
+
+`vehicle_id` は以下と一致させる。
+
+- namespace 名
+- status message 内の vehicle_id
+- frame 名の接頭辞
+
+例:
+- `vehicle_id = car2`
+- namespace = `/car2`
+- frame = `car2/base_link`
+
+### 5.4 race-wide topic
+
+レース全体に関わる topic は `/race/...` 配下に配置する。
+
+- `/race/command`
+- `/race/state`
+- `/race/lap_event`
+- `/race/vehicle_status`
+
+---
+
+## 6. Topic Interface
+
+### 6.1 topic 一覧
+
+| Topic | Type | Publisher | Subscriber | Purpose |
+|------|------|-----------|-----------|---------|
+| `/carX/cmd_drive` | `race_interfaces/DriveCommand` | `gamepad_input_node` / `keyboard_input_node` / `ai_driver_node` | `vehicle_sim_node` / 将来 `race_carla_bridge` | 車両制御入力 |
+| `/carX/odom` | `nav_msgs/Odometry` | `vehicle_sim_node` / 将来 `race_carla_bridge` | `race_manager_node` / `ai_driver_node` / `renderer_node` | 車両状態 |
+| `/race/command` | `race_interfaces/RaceCommand` | `race_command_input_node` / 将来 GUI | `race_manager_node` / `vehicle_sim_node` | レース制御 |
+| `/race/state` | `race_interfaces/RaceState` | `race_manager_node` | `ai_driver_node` / `renderer_node` | レース全体状態 |
+| `/race/lap_event` | `race_interfaces/LapEvent` | `race_manager_node` | `renderer_node` / 将来 logger | ラップイベント |
+| `/race/vehicle_status` | `race_interfaces/VehicleRaceStatus` | `race_manager_node` | `renderer_node` | 車両ごとのレース状態 |
+
+### 6.2 TF
+
+初版では以下の動的 TF を扱う。
+
+- `odom -> carX/base_link`
+
+publisher:
+- 初版: `vehicle_sim_node`
+- 将来: `race_carla_bridge`
+
+静的 TF は初版では不要だが、将来センサ導入時に以下を想定する。
+
+- `carX/base_link -> carX/lidar`
+- `carX/base_link -> carX/camera`
+
+---
+
+## 7. Message Definitions
+
+### 7.1 DriveCommand.msg
+
+車両制御入力を表す。
+
+~~~text
+std_msgs/Header header
+
+float32 throttle_cmd
+float32 steering_cmd
+~~~
+
+#### 意味
+- `throttle_cmd ∈ [-1.0, 1.0]`
+- `steering_cmd ∈ [-1.0, 1.0]`
+
+#### 設計意図
+- 手動入力でも AI 入力でも共通の message を使う
+- controller の種類に依存しない
+- 物理量変換は backend 側で行う
+
+---
+
+### 7.2 RaceCommand.msg
+
+レース操作コマンドを表す。
+
+~~~text
+std_msgs/Header header
+
+uint8 command
+
+uint8 START=0
+uint8 STOP=1
+uint8 RESET=2
+~~~
+
+#### 意味
+- `START`: レース開始
+- `STOP`: レース停止
+- `RESET`: race state / vehicle state 初期化
+
+#### 設計意図
+- typo を防ぐため文字列ではなく定数付き `uint8` を使う
+- GUI / keyboard / external frontend から統一的に使える
+
+---
+
+### 7.3 RaceState.msg
+
+レース全体状態を表す。
+
+~~~text
+std_msgs/Header header
+
+string race_status
+builtin_interfaces/Duration elapsed_time
+
+int32 total_laps
+~~~
+
+#### race_status
+以下の固定値を取る。
+
+- `READY`
+- `COUNTDOWN`
+- `RUNNING`
+- `FINISHED`
+- `STOPPED`
+
+#### elapsed_time
+- `RUNNING` 開始時から加算
+- `COUNTDOWN` は含めない
+- `FINISHED` / `STOPPED` で停止
+
+#### total_laps
+- 規定周回数
+
+---
+
+### 7.4 LapEvent.msg
+
+ラップ成立時に発行されるイベント。
+
+~~~text
+std_msgs/Header header
+
+string vehicle_id
+
+int32 lap_count
+
+builtin_interfaces/Duration lap_time
+builtin_interfaces/Duration best_lap_time
+
+bool has_finished
+~~~
+
+#### 意味
+- `vehicle_id`: ラップ成立車両
+- `lap_count`: 確定したラップ数
+- `lap_time`: 今回ラップ時間
+- `best_lap_time`: その時点のベスト
+- `has_finished`: このラップで完走したか
+
+#### 用途
+- renderer の一時演出
+- logger / analytics 用のイベント通知
+
+---
+
+### 7.5 VehicleRaceStatus.msg
+
+車両ごとの継続レース状態を表す。
+
+~~~text
+std_msgs/Header header
+
+string vehicle_id
+
+int32 lap_count
+
+builtin_interfaces/Duration current_lap_time
+builtin_interfaces/Duration last_lap_time
+builtin_interfaces/Duration best_lap_time
+builtin_interfaces/Duration total_elapsed_time
+
+bool has_finished
+bool is_off_track
+
+int32 off_track_count
+~~~
+
+#### 意味
+- `lap_count`: 完了ラップ数
+- `current_lap_time`: 現在ラップ経過
+- `last_lap_time`: 直前ラップ
+- `best_lap_time`: 最速ラップ
+- `total_elapsed_time`: `RUNNING` 開始からの累積時間
+- `has_finished`: 完走済みか
+- `is_off_track`: 現在コース外か
+- `off_track_count`: 内→外 遷移回数
+
+#### 制約
+この message は **レース進行状態のみ**を表す。  
+以下は含めない。
+
+- 車速
+- 操作入力
+- controller 内部状態
+- 車両運動状態
+
+それらは `Odometry` や config を参照する。
+
+---
+
+### 7.6 Track.msg を作らない方針
+
+初版では `Track.msg` は定義しない。
+
+#### 理由
+- track は file + shared library (`race_track`) で扱う
+- track topic 配信は初版では不要
+- track provider node は作らない
+
+---
+
+## 8. 座標系と時間源
+
+### 8.1 座標系
+
+ROS 側の world / vehicle 状態表現は ROS REP-103 / REP-105 に従う。  
+初版では、RaceManager や AI Driver は ROS座標系を正として扱う。
+
+将来、外部 simulator（CARLA など）との座標差異は adapter / bridge 層で吸収する。
+
+#### 初版 frame
+- world-like frame: `odom`
+- vehicle frame: `carX/base_link`
+
+### 8.2 時間源
+
+全 ROS ノードは **ROS clock** を正とする。
+
+- `node.get_clock().now()` を使用する
+- wall time / sim time は `use_sim_time` により切替可能
+- レースロジックは ROS 時間のみを参照する
+
+将来、外部 simulator が独自時間を持つ場合は bridge / adapter 層で整合させる。
+
+---
+
+## 9. Track Definition
+
+レース論理コースは track file (YAML) により定義する。
+
+### 9.1 必須項目
+
+- `track_name`
+- `centerline`
+- `track_width`
+- `start_line`
+- `forward_hint`
+
+### 9.2 例
+
+~~~yaml
+track_name: example_track
+
+centerline:
+  - [0.0, 0.0]
+  - [10.0, 0.0]
+  - [20.0, 5.0]
+
+track_width: 6.0
+
+start_line:
+  p1: [0.0, -3.0]
+  p2: [0.0, 3.0]
+
+forward_hint: [1.0, 0.0]
+~~~
+
+### 9.3 centerline
+- 2D waypoint 列
+- 等間隔不要
+- closed loop 可
+- 極端に疎な点列は禁止
+
+### 9.4 track_width
+- 固定幅
+- centerline の両側に corridor を持つ
+
+### 9.5 start_line
+- lap 判定用の線分
+- `p1`, `p2` の 2 点で表す
+
+### 9.6 forward_hint
+- intended travel direction を示すベクトル
+- lap の正方向判定に利用する
+
+---
+
+## 10. Map / Track / Scenario Separation
+
+本システムでは以下を明確に分離する。
+
+### 10.1 Physical / Environment Map
+外部環境地図を指す。
+
+例:
+- OpenDRIVE
+- simulator map
+- 将来の competition-provided map
+
+担当:
+- `race_map`
+
+### 10.2 Logical Race Track
+レースや評価に使う論理コースを指す。
+
+内容:
+- centerline
+- start_line
+- forward_hint
+- track_width
+
+担当:
+- `race_track`
+
+### 10.3 Scenario Configuration
+実行条件を指す。
+初版では scenario は複雑な editor や GUI を持たず、YAML file による最小設定とする。
+
+最低限含む内容:
+- total_laps
+- 車両初期配置
+- 手動 / AI の割り当て
+- controller_type
+- input source
+- race settings
+
+### 10.4 重要な設計原則
+外部 map は、そのまま race logic 用 track と同一視しない。  
+必要に応じて map adaptation によって logical track を生成する。
+
+---
+
+## 11. race_track Library Responsibilities
+
+`race_track` は shared library として以下を提供する。
+
+- track YAML parse
+- validation
+- TrackModel の生成
+- centerline 最近点計算
+- point-to-centerline 距離計算
+- lookahead point 計算補助
+- start_line 交差判定補助
+- `forward_hint` / `track_width` / `start_line` の取得
+
+### 11.1 TrackModel
+最低限保持する情報:
+
+- `track_name`
+- `centerline`
+- `track_width`
+- `start_line`
+- `forward_hint`
+
+### 11.2 使用ノード
+以下のノードが `race_track` を利用する。
+
+- `ai_driver_node`
+- `race_manager_node`
+- `renderer_node`
+
+---
+
+## 12. race_map Responsibilities
+
+`race_map` は外部地図資産の読み込み・正規化を担当する。  
+初版では未実装でもよいが、将来 OpenDRIVE を主形式として扱うための責務をここに集約する。
+
+想定機能:
+- external map asset 読み込み
+- OpenDRIVE parse
+- map normalization
+- logical track 生成支援
+- lane / centerline 抽出支援
+
+### 12.1 主形式
+外部地図資産の主形式は **OpenDRIVE** を第一候補とする。
+
+### 12.2 方針
+将来、以下を可能にする。
+
+- OpenDRIVE → logical race track
+- simulator map → logical race track
+- competition-provided map → logical race track
+
+---
+
+## 13. Simulation Backend Policy
+
+### 13.1 初版 backend
+初版の backend は `vehicle_sim_node` とする。
+
+### 13.2 `vehicle_sim_node` の位置づけ
+`vehicle_sim_node` は、初版における **軽量 internal vehicle simulation backend** である。  
+開発・学習・初期検証のために用いる。
+
+### 13.3 将来 backend
+将来的には `race_carla_bridge` を導入し、外部 simulator backend（CARLA）へ置換可能な構造とする。
+
+### 13.4 backend 非依存の契約
+上位ロジックは以下の I/F のみに依存する。
+
+- `/carX/cmd_drive`
+- `/carX/odom`
+- `odom -> carX/base_link`
+
+これにより、internal backend と future backend を差し替え可能にする。
+
+### 13.5 初版の抽象化方針
+初版では backend 差し替え可能性を設計上は維持するが、未使用 backend のための過剰な抽象層は導入しない。
+
+原則:
+- interface 契約は固定する
+- internal backend は単純な実装で成立させる
+- 実際に 2つ以上の実装が必要になるまで汎用 plugin 機構は導入しない
+- class 分離は責務分離のために行い、将来用途だけを理由に増やしすぎない
+
+---
+
+### 13.5 初版の抽象化方針
+初版では backend 差し替え可能性を設計上は維持するが、未使用 backend のための過剰な抽象層は導入しない。
+具体的には以下を原則とする。
+- interface 契約は固定する
+- internal backend は単純な実装で成立させる
+- 実際に 2つ以上の実装が必要になるまで汎用 plugin 機構は導入しない
+- class 分離は責務分離のために行い、将来用途だけを理由に増やしすぎない
+
+---
+
+## 14. vehicle_sim_node Specification
+
+### 14.1 役割
+1台の車両の運動状態をシミュレーションし、ROS標準形式で状態を publish する。
+
+### 14.2 入力
+- `/carX/cmd_drive`
+- `/race/command`（主に `RESET` を処理）
+
+### 14.3 出力
+- `/carX/odom`
+- `odom -> carX/base_link`
+
+### 14.4 車両モデル
+- Kinematic Bicycle Model
+
+### 14.5 パラメータ
+- `vehicle_id`
+- `wheelbase_m`
+- `max_steering_angle_rad`
+- `max_acceleration_mps2`
+- `max_deceleration_mps2`
+- `max_speed_mps`
+- `update_rate_hz`
+- `cmd_timeout_sec`
+- `initial_pose_x`
+- `initial_pose_y`
+- `initial_pose_yaw`
+
+### 14.6 確定値
+- `max_speed_mps = 22.22`（80 km/h）
+
+### 14.7 command timeout
+一定時間 `DriveCommand` を受信しなければ中立入力に戻す。
+
+### 14.8 RESET
+`RESET` を受信したら以下を初期化する。
+
+- pose
+- yaw
+- velocity
+- steering_angle
+- current command
+
+### 14.9 設計制約
+内部責務を分離する。
+
+例:
+- `VehicleDynamics`
+- `DriveCommandAdapter`
+- `OdometryPublisher`
+- `TfPublisher`
+
+将来的に以下へ拡張しやすい構造とする。
+
+- 加速度一次遅れ
+- 操舵速度制限
+- より高次の vehicle model
+
+---
+
+## 15. race_manager_node Specification
+
+### 15.1 役割
+レース全体の進行と、各車両のラップ・タイム・off-track 状態を管理する。
+
+### 15.2 入力
+- `/race/command`
+- `/carX/odom`
+- track file（`race_track` 経由）
+
+### 15.3 出力
+- `/race/state`
+- `/race/lap_event`
+- `/race/vehicle_status`
+
+### 15.4 RaceState
+- `READY`
+- `COUNTDOWN`
+- `RUNNING`
+- `FINISHED`
+- `STOPPED`
+
+### 15.5 RaceCommand
+- `START`
+- `STOP`
+- `RESET`
+
+### 15.6 状態遷移
+- `READY --START--> COUNTDOWN`
+- `COUNTDOWN --timeout--> RUNNING`
+- `RUNNING --finish--> FINISHED`
+- `COUNTDOWN/RUNNING --STOP--> STOPPED`
+- `STOPPED/FINISHED --RESET--> READY`
+
+### 15.7 elapsed_time
+- `RUNNING` 開始から加算
+- `COUNTDOWN` は含めない
+
+### 15.8 ラップ判定
+以下を全て満たすときのみラップ成立。
+
+1. 移動線分が `start_line` と交差
+2. `dot(move_vec, forward_hint) > 0`
+3. cooldown 超過
+4. `race_status == RUNNING`
+5. `has_finished == false`
+6. odom 受信済み
+
+### 15.9 off-track 判定
+- centerline 最近点距離で判定
+- `distance > track_width / 2` で off-track
+- `inside -> outside` の遷移時のみ count を増やす
+
+### 15.10 publish policy
+- `RaceState`: 毎周期
+- `VehicleRaceStatus`: 毎周期
+- `LapEvent`: ラップ成立時のみ
+
+### 15.11 設計制約
+- race_manager は判定専用
+- 表示用文字列整形を持たない
+- renderer が使う継続状態の真実は `VehicleRaceStatus`
+
+---
+
+## 16. ai_driver_node Specification
+
+### 16.1 役割
+1台の AI 車両に対して、自動走行用 `DriveCommand` を生成する。
+
+### 16.2 入力
+- `/carX/odom`
+- `/race/state`
+- track file（`race_track` 経由）
+
+### 16.3 出力
+- `/carX/cmd_drive`
+
+### 16.4 対応 controller
+- `pure_pursuit`
+- `pid_heading`
+
+### 16.5 方針
+- 初版の主 controller は `pure_pursuit`
+- `pid_heading` は比較・学習用途
+- 将来 `stanley`, `mpc` を追加可能な構造とする
+
+### 16.6 target point
+- 毎周期 centerline 最近点を再計算
+- そこから lookahead point を選ぶ
+
+### 16.7 race state との関係
+- `RUNNING` のときのみ制御
+- `READY`, `COUNTDOWN`, `FINISHED`, `STOPPED` では中立入力
+
+### 16.8 速度制御
+共通 speed controller を使う。
+
+- `target_speed`
+- `speed_kp`
+- steering 量に応じた減速
+
+### 16.9 設計制約
+- simulator-independent
+- lap 判定を持たない
+- off-track 判定を持たない
+- 他車回避を持たない
+
+### 16.10 内部構造
+例:
+- `TrackFollower`
+- `TargetPointSelector`
+- `ControllerBase`
+  - `PurePursuitController`
+  - `PidHeadingController`
+- `SpeedController`
+
+### 16.11 初版実装優先順位
+初版 AI の成立条件は `pure_pursuit` による安定周回である。
+`pid_heading` は比較・学習用途の副 controller とし、`pure_pursuit` が成立するまで追加改善を優先しない。
+
+
+---
+
+## 17. input nodes Specification
+
+### 17.1 gamepad_input_node
+役割:
+- gamepad から `DriveCommand` を生成する
+
+対象:
+- 手動操作車両
+
+### 17.2 keyboard_input_node
+役割:
+- キーボード入力から `DriveCommand` を生成する
+
+用途:
+- fallback / debug
+
+### 17.3 race_command_input_node
+役割:
+- `RaceCommand` を publish する
+
+対応:
+- START
+- STOP
+- RESET
+
+### 17.4 設計制約
+- 車両操作入力と race 操作入力は分離する
+- manual input source は同一車両に対して 1つだけ有効
+
+---
+
+## 18. renderer_node Specification
+
+### 18.1 役割
+レースシステムの状態を 2D GUI として可視化する。
+
+### 18.2 入力
+- `/carX/odom`
+- `/race/state`
+- `/race/vehicle_status`
+- `/race/lap_event`
+- track file（`race_track` 経由）
+
+### 18.3 出力
+初版では必須出力なし。
+
+### 18.4 表示内容
+- centerline
+- track width を持つ道路
+- start_line
+- 車両位置
+- 車両向き
+- vehicle_id
+- race_state
+- elapsed_time
+- lap 情報
+- off-track 情報
+- LapEvent の一時表示
+
+### 18.5 設計制約
+- renderer は表示専用
+- race logic を持たない
+- 判定ロジックを持たない
+- 継続表示の真実は `VehicleRaceStatus`
+- `LapEvent` は一時通知用
+
+### 18.6 位置づけ
+`renderer_node` は初版の **暫定可視化 frontend** であり、将来的には simulator-native visualization 等へ置換可能である。
+
+---
+
+## 19. race_carla_bridge Specification (Future)
+
+### 19.1 役割
+CARLA 固有の状態・センサ・制御を ROS2 システム標準 I/F に変換する adapter / bridge とする。
+
+### 19.2 入力
+- `/carX/cmd_drive`
+- CARLA vehicle state
+- 将来の CARLA sensor streams
+
+### 19.3 出力
+- `/carX/odom`
+- TF
+- 将来の sensor topics
+
+### 19.4 設計意図
+上位ロジック (`race_manager`, `ai_driver`) を simulator 非依存に保つ。
+
+---
+
+## 20. Future Sensor Topics (Reserved)
+
+初版では未実装だが、将来追加可能な topic として以下を想定する。
+
+- `/carX/points_raw`
+- `/carX/radar`
+- `/carX/camera/image_raw`
+- `/carX/camera/camera_info`
+
+これらは CARLA 連携フェーズで扱う。
+
+---
+
+## 21. 実装順
+
+推奨実装順は以下の通り。
+
+1. `race_interfaces`
+2. `race_track`
+3. `vehicle_sim_node`
+4. `race_manager_node`
+5. `gamepad_input_node` / `keyboard_input_node` / `race_command_input_node`
+6. `renderer_node`
+7. `ai_driver_node`
+
+各段階で、システムが build / run / inspect 可能であることを重視する。
+
+---
+
+## 22. 受け入れ条件（Acceptance Criteria）
+
+### 22.1 起動
+- 全パッケージが build できる
+- launch により初版システムを起動できる
+
+### 22.2 vehicle state
+- `/carX/odom` が publish される
+- `odom -> carX/base_link` が broadcast される
+
+### 22.3 race logic
+- START / STOP / RESET が動作する
+- RaceState が正しく遷移する
+- lap が数えられる
+- best lap が更新される
+
+### 22.4 off-track
+- `is_off_track` と `off_track_count` が動く
+
+### 22.5 renderer
+- 車両位置と race 状態が表示される
+
+### 22.6 AI
+- `pure_pursuit` で周回可能
+- `pid_heading` を controller として切り替え可能
+
+---
+
+## 23. パッケージ構成
+
+想定パッケージ構成は以下。
+
+- `race_interfaces`
+- `race_track`
+- `race_map`
+- `race_vehicle`
+- `race_ai`
+- `race_manager`
+- `race_renderer`
+- `race_input`
+- `race_bringup`
+- `race_carla_bridge`
+
+---
+
+
+## 24. 本仕様書の位置づけ
+
+本書は、以下の実装・資料の基準となる。
+
+- Architecture Design
+- Implementation Task Breakdown
+- GitHub Issues
+- README / docs
+- future CARLA integration design
+
+本書に定義された interface と責務分離を維持することを、開発上の前提とする。
+


### PR DESCRIPTION
## 概要
ROS2 Race Simulator の仕様書群を見直し、初版実装を軽量に成立させるための方針を明確化した。

## 主な変更
- 初版で禁止する拡張の明記
- 初版実装方針の追加
- Initial Success Criteria の追加
- Node Internal Design Principle の追加
- 時間源の一貫性の明記
- 実装フェーズの完了条件と寄り道禁止ルールの追加
- minimal scenario file の導入方針を追加
- renderer をデバッグ・観測用 frontend として位置づけ明確化

## 目的
- 初版のスコープ膨張を防ぐ
- 責務境界を明確にする
- 実装順を崩さずに動く最小構成を成立させる
- 将来拡張を見据えつつ、初版で過剰実装しないようにする