### PR TITLE
chore: create minimal skeletons for race_interfaces and race_track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+install/
+log/

--- a/src/race_interfaces/CMakeLists.txt
+++ b/src/race_interfaces/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.8)
+project(race_interfaces)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/src/race_interfaces/package.xml
+++ b/src/race_interfaces/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>race_interfaces</name>
+  <version>0.0.0</version>
+  <description>Minimal package skeleton for race interface definitions.</description>
+  <maintainer email="fukuda24@example.com">fukuda24</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.8)
+project(race_track)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/src/race_track/package.xml
+++ b/src/race_track/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>race_track</name>
+  <version>0.0.0</version>
+  <description>Minimal package skeleton for race track utilities.</description>
+  <maintainer email="fukuda24@example.com">fukuda24</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Summary
Create minimal package skeletons for `race_interfaces` and `race_track`.

## Changes
- add `src/race_interfaces/package.xml`
- add `src/race_interfaces/CMakeLists.txt`
- add `src/race_track/package.xml`
- add `src/race_track/CMakeLists.txt`
- update `.gitignore`

## Validation
- `colcon build` passes
- packages are discoverable after sourcing install setup

## Out of scope
- no msg definitions yet
- no track model / yaml loader / geometry / tests / docs changes