### PR TITLE
feat(race_interfaces): add initial ROS2 message definitions

### DIFF
--- a/src/race_interfaces/CMakeLists.txt
+++ b/src/race_interfaces/CMakeLists.txt
@@ -2,5 +2,19 @@ cmake_minimum_required(VERSION 3.8)
 project(race_interfaces)
 
 find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/DriveCommand.msg"
+  "msg/RaceCommand.msg"
+  "msg/RaceState.msg"
+  "msg/LapEvent.msg"
+  "msg/VehicleRaceStatus.msg"
+  DEPENDENCIES
+    builtin_interfaces
+    std_msgs
+)
 
 ament_package()

--- a/src/race_interfaces/msg/DriveCommand.msg
+++ b/src/race_interfaces/msg/DriveCommand.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+
+float32 throttle_cmd
+float32 steering_cmd

--- a/src/race_interfaces/msg/LapEvent.msg
+++ b/src/race_interfaces/msg/LapEvent.msg
@@ -1,0 +1,10 @@
+std_msgs/Header header
+
+string vehicle_id
+
+int32 lap_count
+
+builtin_interfaces/Duration lap_time
+builtin_interfaces/Duration best_lap_time
+
+bool has_finished

--- a/src/race_interfaces/msg/RaceCommand.msg
+++ b/src/race_interfaces/msg/RaceCommand.msg
@@ -1,0 +1,7 @@
+std_msgs/Header header
+
+uint8 command
+
+uint8 START=0
+uint8 STOP=1
+uint8 RESET=2

--- a/src/race_interfaces/msg/RaceState.msg
+++ b/src/race_interfaces/msg/RaceState.msg
@@ -1,0 +1,6 @@
+std_msgs/Header header
+
+string race_status
+builtin_interfaces/Duration elapsed_time
+
+int32 total_laps

--- a/src/race_interfaces/msg/VehicleRaceStatus.msg
+++ b/src/race_interfaces/msg/VehicleRaceStatus.msg
@@ -1,0 +1,15 @@
+std_msgs/Header header
+
+string vehicle_id
+
+int32 lap_count
+
+builtin_interfaces/Duration current_lap_time
+builtin_interfaces/Duration last_lap_time
+builtin_interfaces/Duration best_lap_time
+builtin_interfaces/Duration total_elapsed_time
+
+bool has_finished
+bool is_off_track
+
+int32 off_track_count

--- a/src/race_interfaces/package.xml
+++ b/src/race_interfaces/package.xml
@@ -7,6 +7,14 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
Add the initial ROS2 message definitions for Milestone 1 in `race_interfaces`.

## Changes
- add `DriveCommand.msg`
- add `RaceCommand.msg`
- add `RaceState.msg`
- add `LapEvent.msg`
- add `VehicleRaceStatus.msg`
- update `CMakeLists.txt` for rosidl generation
- update `package.xml` dependencies for interface generation

## Validation
- `colcon build` passes
- `ros2 interface list | grep race_interfaces` shows all 5 messages
- `ros2 interface show` confirms each message definition

## Spec review
Confirmed against `docs/specification.md`:
- `header` is required for all 5 messages
- `race_status` is specified as `string`
- `lap_count`, `total_laps`, and `off_track_count` are specified as `int32`

## Out of scope
- no `Track.msg`
- no services/actions
- no helper libraries
- no changes outside `race_interfaces`