### PR TITLE
feat(race_track): add minimal track model and geometry types

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -3,4 +3,23 @@ project(race_track)
 
 find_package(ament_cmake REQUIRED)
 
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+)
+
+ament_export_include_directories(include)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
 ament_package()

--- a/src/race_track/include/race_track/track_model.hpp
+++ b/src/race_track/include/race_track/track_model.hpp
@@ -1,0 +1,23 @@
+#ifndef RACE_TRACK__TRACK_MODEL_HPP_
+#define RACE_TRACK__TRACK_MODEL_HPP_
+
+#include <string>
+#include <vector>
+
+#include "race_track/types.hpp"
+
+namespace race_track
+{
+
+struct TrackModel
+{
+  std::string track_name{};
+  std::vector<Point2d> centerline{};
+  double track_width{0.0};
+  LineSegment2d start_line{};
+  Point2d forward_hint{};
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__TRACK_MODEL_HPP_

--- a/src/race_track/include/race_track/types.hpp
+++ b/src/race_track/include/race_track/types.hpp
@@ -1,0 +1,21 @@
+#ifndef RACE_TRACK__TYPES_HPP_
+#define RACE_TRACK__TYPES_HPP_
+
+namespace race_track
+{
+
+struct Point2d
+{
+  double x{0.0};
+  double y{0.0};
+};
+
+struct LineSegment2d
+{
+  Point2d p1{};
+  Point2d p2{};
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__TYPES_HPP_


### PR DESCRIPTION
## Summary
Add minimal geometry types and `TrackModel` to `race_track` as the foundation for later loader, validation, and geometry work.

## Changes
- add `Point2d` and `LineSegment2d` in `types.hpp`
- add `TrackModel` in `track_model.hpp`
- update `CMakeLists.txt` to export/install public headers as a header-only package

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `source install/setup.bash`
- `colcon build --packages-select race_track` passes

## Notes
- header-only minimal public package
- no loader / validation / geometry utility yet
- no yaml-cpp or test dependencies added