### PR TITLE
feat(race_track): add YAML loader for track model

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -2,16 +2,25 @@ cmake_minimum_required(VERSION 3.8)
 project(race_track)
 
 find_package(ament_cmake REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE
+add_library(${PROJECT_NAME}
+  src/track_loader.cpp
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp)
 
 install(
   DIRECTORY include/
   DESTINATION include
+)
+
+install(
+  DIRECTORY config/
+  DESTINATION share/${PROJECT_NAME}
 )
 
 install(
@@ -20,6 +29,7 @@ install(
 )
 
 ament_export_include_directories(include)
+ament_export_dependencies(yaml-cpp)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_package()

--- a/src/race_track/config/sample_track.yaml
+++ b/src/race_track/config/sample_track.yaml
@@ -1,0 +1,19 @@
+track_name: sample_track
+centerline:
+  - x: 0.0
+    y: 0.0
+  - x: 10.0
+    y: 0.0
+  - x: 20.0
+    y: 5.0
+track_width: 6.5
+start_line:
+  p1:
+    x: 0.0
+    y: -3.25
+  p2:
+    x: 0.0
+    y: 3.25
+forward_hint:
+  x: 1.0
+  y: 0.0

--- a/src/race_track/include/race_track/track_loader.hpp
+++ b/src/race_track/include/race_track/track_loader.hpp
@@ -1,0 +1,15 @@
+#ifndef RACE_TRACK__TRACK_LOADER_HPP_
+#define RACE_TRACK__TRACK_LOADER_HPP_
+
+#include <string>
+
+#include "race_track/track_model.hpp"
+
+namespace race_track
+{
+
+TrackModel loadTrackFromYaml(const std::string & yaml_path);
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__TRACK_LOADER_HPP_

--- a/src/race_track/package.xml
+++ b/src/race_track/package.xml
@@ -7,6 +7,8 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>yaml-cpp</build_depend>
+  <exec_depend>yaml-cpp</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/race_track/src/track_loader.cpp
+++ b/src/race_track/src/track_loader.cpp
@@ -1,0 +1,72 @@
+#include "race_track/track_loader.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+namespace race_track
+{
+namespace
+{
+
+YAML::Node requireKey(const YAML::Node & node, const std::string & key, const std::string & context)
+{
+  const YAML::Node value = node[key];
+  if (!value) {
+    throw std::runtime_error("Missing required key '" + context + key + "'");
+  }
+  return value;
+}
+
+Point2d parsePoint2d(const YAML::Node & node, const std::string & context)
+{
+  try {
+    return Point2d{
+      requireKey(node, "x", context + ".").as<double>(),
+      requireKey(node, "y", context + ".").as<double>()};
+  } catch (const YAML::Exception & ex) {
+    throw std::runtime_error("Failed to parse key '" + context + "': " + ex.what());
+  }
+}
+
+LineSegment2d parseLineSegment2d(const YAML::Node & node, const std::string & context)
+{
+  return LineSegment2d{
+    parsePoint2d(requireKey(node, "p1", context + "."), context + ".p1"),
+    parsePoint2d(requireKey(node, "p2", context + "."), context + ".p2")};
+}
+
+}  // namespace
+
+TrackModel loadTrackFromYaml(const std::string & yaml_path)
+{
+  YAML::Node root;
+  try {
+    root = YAML::LoadFile(yaml_path);
+  } catch (const YAML::Exception & ex) {
+    throw std::runtime_error("Failed to parse YAML file '" + yaml_path + "': " + ex.what());
+  }
+
+  try {
+    TrackModel track;
+    track.track_name = requireKey(root, "track_name", "").as<std::string>();
+
+    const YAML::Node centerline_node = requireKey(root, "centerline", "");
+    if (!centerline_node.IsSequence()) {
+      throw std::runtime_error("Failed to parse key 'centerline': expected sequence");
+    }
+    for (std::size_t i = 0; i < centerline_node.size(); ++i) {
+      track.centerline.push_back(parsePoint2d(centerline_node[i], "centerline[" + std::to_string(i) + "]"));
+    }
+
+    track.track_width = requireKey(root, "track_width", "").as<double>();
+    track.start_line = parseLineSegment2d(requireKey(root, "start_line", ""), "start_line");
+    track.forward_hint = parsePoint2d(requireKey(root, "forward_hint", ""), "forward_hint");
+    return track;
+  } catch (const YAML::Exception & ex) {
+    throw std::runtime_error("Failed to parse track YAML '" + yaml_path + "': " + ex.what());
+  }
+}
+
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Add a minimal YAML loader for `TrackModel` in `race_track`.

## Changes
- add `loadTrackFromYaml(const std::string &)` API
- implement YAML parsing with yaml-cpp
- add `config/sample_track.yaml`
- update `CMakeLists.txt` and `package.xml` for yaml-cpp dependency

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `colcon build --packages-select race_track` passes
- sample YAML load succeeds
- missing required keys fail with `std::runtime_error`
- malformed YAML fails with `std::runtime_error`

## Out of scope
- no semantic validation yet
- no geometry utility
- no additional abstractions