### PR TITLE
feat(race_track): add minimal track validation

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(yaml-cpp REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/track_loader.cpp
+  src/track_validator.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/race_track/include/race_track/track_validator.hpp
+++ b/src/race_track/include/race_track/track_validator.hpp
@@ -1,0 +1,13 @@
+#ifndef RACE_TRACK__TRACK_VALIDATOR_HPP_
+#define RACE_TRACK__TRACK_VALIDATOR_HPP_
+
+#include "race_track/track_model.hpp"
+
+namespace race_track
+{
+
+void validateTrackOrThrow(const TrackModel & track);
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__TRACK_VALIDATOR_HPP_

--- a/src/race_track/src/track_validator.cpp
+++ b/src/race_track/src/track_validator.cpp
@@ -1,0 +1,62 @@
+#include "race_track/track_validator.hpp"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace race_track
+{
+namespace
+{
+
+bool isZeroVector(const Point2d & point)
+{
+  return point.x == 0.0 && point.y == 0.0;
+}
+
+bool isZeroLengthSegment(const LineSegment2d & segment)
+{
+  return segment.p1.x == segment.p2.x && segment.p1.y == segment.p2.y;
+}
+
+std::string formatPoint(const Point2d & point)
+{
+  std::ostringstream oss;
+  oss << "(" << point.x << ", " << point.y << ")";
+  return oss.str();
+}
+
+}  // namespace
+
+void validateTrackOrThrow(const TrackModel & track)
+{
+  if (track.track_name.empty()) {
+    throw std::runtime_error("Invalid track: 'track_name' must not be empty");
+  }
+
+  if (track.centerline.size() < 3U) {
+    throw std::runtime_error(
+            "Invalid track '" + track.track_name + "': 'centerline' must contain at least 3 points, got " +
+            std::to_string(track.centerline.size()));
+  }
+
+  if (track.track_width <= 0.0) {
+    throw std::runtime_error(
+            "Invalid track '" + track.track_name + "': 'track_width' must be greater than 0, got " +
+            std::to_string(track.track_width));
+  }
+
+  if (isZeroLengthSegment(track.start_line)) {
+    throw std::runtime_error(
+            "Invalid track '" + track.track_name +
+            "': 'start_line' must not be zero-length; p1=" + formatPoint(track.start_line.p1) +
+            ", p2=" + formatPoint(track.start_line.p2));
+  }
+
+  if (isZeroVector(track.forward_hint)) {
+    throw std::runtime_error(
+            "Invalid track '" + track.track_name +
+            "': 'forward_hint' must not be the zero vector; got " + formatPoint(track.forward_hint));
+  }
+}
+
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Add minimal validation for `TrackModel` in `race_track`.

## Changes
- add `validateTrackOrThrow(const TrackModel &)` API
- validate:
  - non-empty `track_name`
  - `centerline.size() >= 3`
  - `track_width > 0`
  - non-zero-length `start_line`
  - non-zero `forward_hint`
- update `CMakeLists.txt` to compile the validator source

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `colcon build --packages-select race_track` passes

## Out of scope
- no YAML parsing
- no geometry utility
- no auto-repair
- no advanced topology checks