### PR TITLE
test(race_track): add unit tests for loader, validator, and geometry

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -30,6 +30,25 @@ install(
   EXPORT export_${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_track_loader
+    test/test_track_loader.cpp
+  )
+  target_link_libraries(test_track_loader ${PROJECT_NAME})
+
+  ament_add_gtest(test_track_validator
+    test/test_track_validator.cpp
+  )
+  target_link_libraries(test_track_validator ${PROJECT_NAME})
+
+  ament_add_gtest(test_geometry
+    test/test_geometry.cpp
+  )
+  target_link_libraries(test_geometry ${PROJECT_NAME})
+endif()
+
 ament_export_include_directories(include)
 ament_export_dependencies(yaml-cpp)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/src/race_track/test/test_geometry.cpp
+++ b/src/race_track/test/test_geometry.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "race_track/geometry.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TEST(GeometryTest, FindsNearestCenterlineIndexForRepresentativePoint)
+{
+  const std::vector<Point2d> centerline = {
+    {0.0, 0.0},
+    {5.0, 0.0},
+    {10.0, 0.0},
+    {15.0, 5.0},
+  };
+
+  const std::size_t nearest_index = findNearestCenterlineIndex(centerline, Point2d{11.0, 1.0});
+
+  EXPECT_EQ(nearest_index, 2U);
+}
+
+TEST(GeometryTest, ComputesMinimumDistanceToCenterlineSegments)
+{
+  const std::vector<Point2d> centerline = {
+    {0.0, 0.0},
+    {10.0, 0.0},
+    {10.0, 10.0},
+  };
+
+  const double distance = distanceToCenterline(centerline, Point2d{8.0, 3.0});
+
+  EXPECT_DOUBLE_EQ(distance, 2.0);
+}
+
+TEST(GeometryTest, DetectsForwardCrossingOfStartLine)
+{
+  const LineSegment2d start_line{{0.0, -2.0}, {0.0, 2.0}};
+
+  EXPECT_TRUE(isForwardCrossingStartLine(
+    Point2d{-1.0, 0.0}, Point2d{1.0, 0.0}, start_line, Point2d{1.0, 0.0}));
+}
+
+TEST(GeometryTest, ReturnsFalseForReverseCrossing)
+{
+  const LineSegment2d start_line{{0.0, -2.0}, {0.0, 2.0}};
+
+  EXPECT_FALSE(isForwardCrossingStartLine(
+    Point2d{1.0, 0.0}, Point2d{-1.0, 0.0}, start_line, Point2d{1.0, 0.0}));
+}
+
+TEST(GeometryTest, ReturnsFalseWhenSegmentDoesNotIntersectStartLine)
+{
+  const LineSegment2d start_line{{0.0, -2.0}, {0.0, 2.0}};
+
+  EXPECT_FALSE(isForwardCrossingStartLine(
+    Point2d{1.0, 3.0}, Point2d{2.0, 3.0}, start_line, Point2d{1.0, 0.0}));
+}
+
+}  // namespace
+}  // namespace race_track

--- a/src/race_track/test/test_track_loader.cpp
+++ b/src/race_track/test/test_track_loader.cpp
@@ -1,0 +1,145 @@
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <functional>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+#include "race_track/track_loader.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+std::string getSampleTrackPath()
+{
+  return (
+    std::filesystem::path(__FILE__).parent_path().parent_path() / "config" / "sample_track.yaml").string();
+}
+
+class TemporaryYamlFile
+{
+public:
+  explicit TemporaryYamlFile(const std::string & contents)
+  {
+    char path_template[] = "/tmp/race_track_loader_test_XXXXXX.yaml";
+    const int fd = mkstemps(path_template, 5);
+    if (fd == -1) {
+      throw std::runtime_error("Failed to create temporary YAML file");
+    }
+
+    path_ = path_template;
+
+    std::ofstream output(path_);
+    if (!output.is_open()) {
+      close(fd);
+      std::remove(path_.c_str());
+      throw std::runtime_error("Failed to open temporary YAML file for writing");
+    }
+
+    output << contents;
+    output.close();
+    close(fd);
+  }
+
+  ~TemporaryYamlFile()
+  {
+    if (!path_.empty()) {
+      std::remove(path_.c_str());
+    }
+  }
+
+  const std::string & path() const
+  {
+    return path_;
+  }
+
+private:
+  std::string path_{};
+};
+
+void expectRuntimeErrorContains(
+  const std::function<void()> & fn, const std::string & expected_substring)
+{
+  try {
+    fn();
+    FAIL() << "Expected std::runtime_error containing: " << expected_substring;
+  } catch (const std::runtime_error & ex) {
+    EXPECT_NE(std::string(ex.what()).find(expected_substring), std::string::npos)
+      << "Actual message: " << ex.what();
+  } catch (...) {
+    FAIL() << "Expected std::runtime_error";
+  }
+}
+
+}  // namespace
+
+TEST(TrackLoaderTest, LoadsSampleTrackYaml)
+{
+  const TrackModel track = loadTrackFromYaml(getSampleTrackPath());
+
+  EXPECT_EQ(track.track_name, "sample_track");
+  ASSERT_EQ(track.centerline.size(), 3U);
+  EXPECT_DOUBLE_EQ(track.centerline[0].x, 0.0);
+  EXPECT_DOUBLE_EQ(track.centerline[0].y, 0.0);
+  EXPECT_DOUBLE_EQ(track.centerline[1].x, 10.0);
+  EXPECT_DOUBLE_EQ(track.centerline[1].y, 0.0);
+  EXPECT_DOUBLE_EQ(track.centerline[2].x, 20.0);
+  EXPECT_DOUBLE_EQ(track.centerline[2].y, 5.0);
+  EXPECT_DOUBLE_EQ(track.track_width, 6.5);
+  EXPECT_DOUBLE_EQ(track.start_line.p1.x, 0.0);
+  EXPECT_DOUBLE_EQ(track.start_line.p1.y, -3.25);
+  EXPECT_DOUBLE_EQ(track.start_line.p2.x, 0.0);
+  EXPECT_DOUBLE_EQ(track.start_line.p2.y, 3.25);
+  EXPECT_DOUBLE_EQ(track.forward_hint.x, 1.0);
+  EXPECT_DOUBLE_EQ(track.forward_hint.y, 0.0);
+}
+
+TEST(TrackLoaderTest, ThrowsWhenRequiredKeyIsMissing)
+{
+  const TemporaryYamlFile yaml_file(R"(
+track_name: sample_track
+centerline:
+  - x: 0.0
+    y: 0.0
+  - x: 10.0
+    y: 0.0
+  - x: 20.0
+    y: 5.0
+start_line:
+  p1:
+    x: 0.0
+    y: -3.25
+  p2:
+    x: 0.0
+    y: 3.25
+forward_hint:
+  x: 1.0
+  y: 0.0
+)");
+
+  expectRuntimeErrorContains(
+    [&yaml_file]() { (void)loadTrackFromYaml(yaml_file.path()); }, "Missing required key 'track_width'");
+}
+
+TEST(TrackLoaderTest, ThrowsWhenYamlIsMalformed)
+{
+  const TemporaryYamlFile yaml_file(R"(
+track_name: broken
+centerline:
+  - x: 0.0
+    y: 0.0
+  - x: 1.0
+    y: [1.0
+)");
+
+  expectRuntimeErrorContains(
+    [&yaml_file]() { (void)loadTrackFromYaml(yaml_file.path()); }, "Failed to parse YAML file");
+}
+
+}  // namespace race_track

--- a/src/race_track/test/test_track_validator.cpp
+++ b/src/race_track/test/test_track_validator.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <stdexcept>
+#include <string>
+
+#include "race_track/track_model.hpp"
+#include "race_track/track_validator.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TrackModel makeValidTrack()
+{
+  TrackModel track;
+  track.track_name = "unit_test_track";
+  track.centerline = {{0.0, 0.0}, {5.0, 0.0}, {10.0, 2.0}};
+  track.track_width = 4.0;
+  track.start_line = {{0.0, -2.0}, {0.0, 2.0}};
+  track.forward_hint = {1.0, 0.0};
+  return track;
+}
+
+void expectRuntimeErrorContains(
+  const std::function<void()> & fn, const std::string & expected_substring)
+{
+  try {
+    fn();
+    FAIL() << "Expected std::runtime_error containing: " << expected_substring;
+  } catch (const std::runtime_error & ex) {
+    EXPECT_NE(std::string(ex.what()).find(expected_substring), std::string::npos)
+      << "Actual message: " << ex.what();
+  } catch (...) {
+    FAIL() << "Expected std::runtime_error";
+  }
+}
+
+}  // namespace
+
+TEST(TrackValidatorTest, AcceptsValidTrackModel)
+{
+  EXPECT_NO_THROW(validateTrackOrThrow(makeValidTrack()));
+}
+
+TEST(TrackValidatorTest, ThrowsWhenTrackNameIsEmpty)
+{
+  TrackModel track = makeValidTrack();
+  track.track_name.clear();
+
+  expectRuntimeErrorContains(
+    [&track]() { validateTrackOrThrow(track); }, "'track_name' must not be empty");
+}
+
+TEST(TrackValidatorTest, ThrowsWhenCenterlineHasFewerThanThreePoints)
+{
+  TrackModel track = makeValidTrack();
+  track.centerline = {{0.0, 0.0}, {1.0, 0.0}};
+
+  expectRuntimeErrorContains(
+    [&track]() { validateTrackOrThrow(track); }, "'centerline' must contain at least 3 points");
+}
+
+TEST(TrackValidatorTest, ThrowsWhenTrackWidthIsNonPositive)
+{
+  TrackModel track = makeValidTrack();
+  track.track_width = 0.0;
+
+  expectRuntimeErrorContains(
+    [&track]() { validateTrackOrThrow(track); }, "'track_width' must be greater than 0");
+}
+
+TEST(TrackValidatorTest, ThrowsWhenStartLineHasZeroLength)
+{
+  TrackModel track = makeValidTrack();
+  track.start_line = {{1.0, 1.0}, {1.0, 1.0}};
+
+  expectRuntimeErrorContains(
+    [&track]() { validateTrackOrThrow(track); }, "'start_line' must not be zero-length");
+}
+
+TEST(TrackValidatorTest, ThrowsWhenForwardHintIsZeroVector)
+{
+  TrackModel track = makeValidTrack();
+  track.forward_hint = {0.0, 0.0};
+
+  expectRuntimeErrorContains(
+    [&track]() { validateTrackOrThrow(track); }, "'forward_hint' must not be the zero vector");
+}
+
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Add unit tests for `race_track` loader, validator, and geometry utilities.

## Changes
- add loader tests
- add validator tests
- add geometry tests
- update `CMakeLists.txt` to use `ament_cmake_gtest`

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `colcon test --packages-select race_track`
- `colcon test-result --verbose`

## Notes
- tests cover normal and representative failure cases
- geometry tests include segment-distance behavior and forward crossing behavior

## Out of scope
- no production code changes
- no docs changes
- no additional abstractions