### PR TITLE
feat(demo): add race progress monitor node

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -55,6 +55,11 @@ target_link_libraries(race_progress_publisher
 )
 ament_target_dependencies(race_progress_publisher rclcpp race_interfaces)
 
+add_executable(race_progress_monitor
+  src/race_progress_monitor.cpp
+)
+ament_target_dependencies(race_progress_monitor rclcpp race_interfaces)
+
 install(
   DIRECTORY include/
   DESTINATION include
@@ -67,6 +72,7 @@ install(
 
 install(
   TARGETS ${PROJECT_NAME} track_demo race_progress_demo race_message_demo race_progress_publisher
+    race_progress_monitor
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/src/race_track/src/race_progress_monitor.cpp
+++ b/src/race_track/src/race_progress_monitor.cpp
@@ -1,0 +1,89 @@
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "builtin_interfaces/msg/duration.hpp"
+#include "race_interfaces/msg/lap_event.hpp"
+#include "race_interfaces/msg/race_state.hpp"
+#include "race_interfaces/msg/vehicle_race_status.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+std::string formatDuration(const builtin_interfaces::msg::Duration & duration)
+{
+  std::ostringstream stream;
+  stream << duration.sec << "." << duration.nanosec;
+  return stream.str();
+}
+
+class RaceProgressMonitor : public rclcpp::Node
+{
+public:
+  RaceProgressMonitor()
+  : Node("race_progress_monitor")
+  {
+    race_state_subscriber_ = create_subscription<race_interfaces::msg::RaceState>(
+      "/race_state", 10,
+      std::bind(&RaceProgressMonitor::onRaceState, this, std::placeholders::_1));
+    vehicle_status_subscriber_ =
+      create_subscription<race_interfaces::msg::VehicleRaceStatus>(
+      "/vehicle_race_status", 10,
+      std::bind(&RaceProgressMonitor::onVehicleRaceStatus, this, std::placeholders::_1));
+    lap_event_subscriber_ = create_subscription<race_interfaces::msg::LapEvent>(
+      "/lap_event", 10,
+      std::bind(&RaceProgressMonitor::onLapEvent, this, std::placeholders::_1));
+
+    RCLCPP_INFO(
+      get_logger(),
+      "Monitoring /race_state, /vehicle_race_status, and /lap_event");
+  }
+
+private:
+  void onRaceState(const race_interfaces::msg::RaceState::SharedPtr msg) const
+  {
+    RCLCPP_INFO(
+      get_logger(), "race_state status=%s elapsed=%s total_laps=%d",
+      msg->race_status.c_str(), formatDuration(msg->elapsed_time).c_str(), msg->total_laps);
+  }
+
+  void onVehicleRaceStatus(
+    const race_interfaces::msg::VehicleRaceStatus::SharedPtr msg) const
+  {
+    RCLCPP_INFO(
+      get_logger(),
+      "vehicle_race_status vehicle_id=%s lap_count=%d current_lap_time=%s is_off_track=%s "
+      "off_track_count=%d",
+      msg->vehicle_id.c_str(), msg->lap_count, formatDuration(msg->current_lap_time).c_str(),
+      msg->is_off_track ? "true" : "false", msg->off_track_count);
+  }
+
+  void onLapEvent(const race_interfaces::msg::LapEvent::SharedPtr msg) const
+  {
+    RCLCPP_INFO(
+      get_logger(), "lap_event vehicle_id=%s lap_count=%d lap_time=%s best_lap_time=%s",
+      msg->vehicle_id.c_str(), msg->lap_count, formatDuration(msg->lap_time).c_str(),
+      formatDuration(msg->best_lap_time).c_str());
+  }
+
+  rclcpp::Subscription<race_interfaces::msg::RaceState>::SharedPtr race_state_subscriber_;
+  rclcpp::Subscription<race_interfaces::msg::VehicleRaceStatus>::SharedPtr
+    vehicle_status_subscriber_;
+  rclcpp::Subscription<race_interfaces::msg::LapEvent>::SharedPtr lap_event_subscriber_;
+};
+
+}  // namespace
+
+}  // namespace race_track
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<race_track::RaceProgressMonitor>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
Add a minimal monitor node that subscribes to race progress topics and prints concise summaries.

## Changes
- add `race_progress_monitor.cpp`
- update `race_track/CMakeLists.txt` to build and install the monitor executable

## Monitor behavior
- subscribe to `/race_state`
- subscribe to `/vehicle_race_status`
- subscribe to `/lap_event`
- print concise one-line summaries for each received message

## Logged fields
- `RaceState`
  - `race_status`
  - `elapsed_time`
  - `total_laps`
- `VehicleRaceStatus`
  - `vehicle_id`
  - `lap_count`
  - `current_lap_time`
  - `is_off_track`
  - `off_track_count`
- `LapEvent`
  - `vehicle_id`
  - `lap_count`
  - `lap_time`
  - `best_lap_time`

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `colcon build --packages-select race_track race_interfaces`
- `source install/setup.bash`
- run `race_progress_publisher`
- run `race_progress_monitor`
- publish `RaceCommand` START / STOP / RESET
- confirm monitor logs for `/race_state`, `/vehicle_race_status`, and `/lap_event`

## Out of scope
- no message caching
- no aggregation logic
- no GUI
- no multi-vehicle support