### PR TITLE
feat(demo): add launch file for race progress demo

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -71,6 +71,11 @@ install(
 )
 
 install(
+  DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
   TARGETS ${PROJECT_NAME} track_demo race_progress_demo race_message_demo race_progress_publisher
     race_progress_monitor
   EXPORT export_${PROJECT_NAME}

--- a/src/race_track/launch/race_progress_demo.launch.py
+++ b/src/race_track/launch/race_progress_demo.launch.py
@@ -1,0 +1,17 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package="race_track",
+            executable="race_progress_publisher",
+            output="screen",
+        ),
+        Node(
+            package="race_track",
+            executable="race_progress_monitor",
+            output="screen",
+        ),
+    ])

--- a/src/race_track/package.xml
+++ b/src/race_track/package.xml
@@ -11,6 +11,7 @@
   <depend>race_interfaces</depend>
   <build_depend>yaml-cpp</build_depend>
   <exec_depend>yaml-cpp</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
Add a minimal launch file to start the race progress demo system with a single command.

## Changes
- add `launch/race_progress_demo.launch.py`
- install the `launch/` directory in `CMakeLists.txt`
- add `launch_ros` runtime dependency in `package.xml`

## Launch behavior
`ros2 launch race_track race_progress_demo.launch.py` starts:
- `race_progress_publisher`
- `race_progress_monitor`

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `colcon build --packages-select race_track race_interfaces`
- `source install/setup.bash`
- `ros2 launch race_track race_progress_demo.launch.py`
- confirmed START / STOP / RESET control via `/race_command`
- confirmed monitor output for:
  - `/race_state`
  - `/vehicle_race_status`
  - `/lap_event`

## Out of scope
- no launch arguments
- no namespaces/remapping
- no multi-vehicle support
- no additional orchestration