### PR TITLE
feat(demo): add RaceCommand helper CLI

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -60,6 +60,11 @@ add_executable(race_progress_monitor
 )
 ament_target_dependencies(race_progress_monitor rclcpp race_interfaces)
 
+add_executable(race_command_cli
+  src/race_command_cli.cpp
+)
+ament_target_dependencies(race_command_cli rclcpp race_interfaces)
+
 install(
   DIRECTORY include/
   DESTINATION include
@@ -77,7 +82,7 @@ install(
 
 install(
   TARGETS ${PROJECT_NAME} track_demo race_progress_demo race_message_demo race_progress_publisher
-    race_progress_monitor
+    race_progress_monitor race_command_cli
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/src/race_track/src/race_command_cli.cpp
+++ b/src/race_track/src/race_command_cli.cpp
@@ -1,0 +1,86 @@
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string_view>
+
+#include "race_interfaces/msg/race_command.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace
+{
+
+constexpr char kTopicName[] = "/race_command";
+constexpr char kFrameId[] = "map";
+constexpr auto kPublisherSetupDelay = std::chrono::milliseconds(200);
+constexpr auto kPublishFlushDelay = std::chrono::milliseconds(200);
+
+void printUsage(const char * program_name)
+{
+  std::fprintf(
+    stderr, "Usage: %s <start|stop|reset>\n", program_name != nullptr ? program_name : "race_command_cli");
+}
+
+bool parseCommand(
+  const std::string_view argument, std::uint8_t & command_value, const char *& command_name)
+{
+  if (argument == "start") {
+    command_value = race_interfaces::msg::RaceCommand::START;
+    command_name = "START";
+    return true;
+  }
+
+  if (argument == "stop") {
+    command_value = race_interfaces::msg::RaceCommand::STOP;
+    command_name = "STOP";
+    return true;
+  }
+
+  if (argument == "reset") {
+    command_value = race_interfaces::msg::RaceCommand::RESET;
+    command_name = "RESET";
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2) {
+    printUsage(argc > 0 ? argv[0] : nullptr);
+    return 1;
+  }
+
+  std::uint8_t command_value = 0U;
+  const char * command_name = nullptr;
+  if (!parseCommand(argv[1], command_value, command_name)) {
+    std::fprintf(stderr, "Invalid command: %s\n", argv[1]);
+    printUsage(argv[0]);
+    return 1;
+  }
+
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<rclcpp::Node>("race_command_cli");
+  auto publisher = node->create_publisher<race_interfaces::msg::RaceCommand>(kTopicName, 10);
+
+  rclcpp::sleep_for(kPublisherSetupDelay);
+
+  race_interfaces::msg::RaceCommand message;
+  message.header.stamp = node->get_clock()->now();
+  message.header.frame_id = kFrameId;
+  message.command = command_value;
+  publisher->publish(message);
+
+  RCLCPP_INFO(node->get_logger(), "sent %s", command_name);
+
+  rclcpp::spin_some(node);
+  rclcpp::sleep_for(kPublishFlushDelay);
+  rclcpp::spin_some(node);
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
Add a minimal helper CLI for sending `RaceCommand` messages.

## Changes
- add `race_command_cli.cpp`
- update `race_track/CMakeLists.txt` to build and install the CLI executable

## CLI behavior
- `ros2 run race_track race_command_cli start`
  - sends `RaceCommand::START`
- `ros2 run race_track race_command_cli stop`
  - sends `RaceCommand::STOP`
- `ros2 run race_track race_command_cli reset`
  - sends `RaceCommand::RESET`

## Implementation notes
- publishes once to `/race_command`
- sets `header.frame_id = "map"`
- waits briefly before and after publish to reduce DDS discovery / flush timing issues
- prints a short confirmation log

## Validation
- `source /opt/ros/jazzy/setup.bash`
- `colcon build --packages-select race_track race_interfaces`
- `source install/setup.bash`
- `ros2 launch race_track race_progress_demo.launch.py`
- `ros2 run race_track race_command_cli start`
- `ros2 run race_track race_command_cli stop`
- `ros2 run race_track race_command_cli reset`
- confirmed publisher / monitor react as expected

## Out of scope
- no interactive UI
- no repeated command scheduling
- no service/action interface