### PR TITLE
refactor: extract single-vehicle progress tracking from publisher

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(yaml-cpp REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/geometry.cpp
+  src/progress_tracker.cpp
   src/track_loader.cpp
   src/track_validator.cpp
 )
@@ -106,6 +107,11 @@ if(BUILD_TESTING)
     test/test_geometry.cpp
   )
   target_link_libraries(test_geometry ${PROJECT_NAME})
+
+  ament_add_gtest(test_progress_tracker
+    test/test_progress_tracker.cpp
+  )
+  target_link_libraries(test_progress_tracker ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)

--- a/src/race_track/include/race_track/progress_tracker.hpp
+++ b/src/race_track/include/race_track/progress_tracker.hpp
@@ -1,0 +1,54 @@
+#ifndef RACE_TRACK__PROGRESS_TRACKER_HPP_
+#define RACE_TRACK__PROGRESS_TRACKER_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "race_track/track_model.hpp"
+
+namespace race_track
+{
+
+struct ProgressSnapshot
+{
+  std::int32_t lap_count{0};
+  std::int32_t off_track_count{0};
+  std::int32_t lap_start_step_sec{0};
+  std::int32_t last_lap_time_sec{0};
+  std::int32_t best_lap_time_sec{0};
+  bool has_finished{false};
+};
+
+struct ProgressUpdate
+{
+  ProgressSnapshot snapshot{};
+  std::size_t nearest_centerline_index{0U};
+  double distance_to_centerline{0.0};
+  bool is_off_track{false};
+  bool crossing_detected{false};
+  std::int32_t crossed_lap_time_sec{0};
+};
+
+class ProgressTracker
+{
+public:
+  explicit ProgressTracker(const TrackModel & track);
+
+  void reset();
+
+  void setHasFinished(bool has_finished);
+
+  ProgressUpdate update(std::int32_t step_sec, const Point2d & current_position);
+
+  ProgressSnapshot snapshot() const;
+
+private:
+  TrackModel track_;
+  ProgressSnapshot snapshot_{};
+  bool has_previous_position_{false};
+  Point2d previous_position_{};
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__PROGRESS_TRACKER_HPP_

--- a/src/race_track/package.xml
+++ b/src/race_track/package.xml
@@ -12,6 +12,7 @@
   <build_depend>yaml-cpp</build_depend>
   <exec_depend>yaml-cpp</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/race_track/src/progress_tracker.cpp
+++ b/src/race_track/src/progress_tracker.cpp
@@ -1,0 +1,64 @@
+#include "race_track/progress_tracker.hpp"
+
+#include "race_track/geometry.hpp"
+
+namespace race_track
+{
+
+ProgressTracker::ProgressTracker(const TrackModel & track)
+: track_(track)
+{
+}
+
+void ProgressTracker::reset()
+{
+  snapshot_ = ProgressSnapshot{};
+  has_previous_position_ = false;
+  previous_position_ = Point2d{};
+}
+
+void ProgressTracker::setHasFinished(const bool has_finished)
+{
+  snapshot_.has_finished = has_finished;
+}
+
+ProgressUpdate ProgressTracker::update(
+  const std::int32_t step_sec, const Point2d & current_position)
+{
+  ProgressUpdate update;
+  update.nearest_centerline_index =
+    findNearestCenterlineIndex(track_.centerline, current_position);
+  update.distance_to_centerline = distanceToCenterline(track_.centerline, current_position);
+  update.is_off_track = update.distance_to_centerline > (track_.track_width / 2.0);
+  if (update.is_off_track) {
+    ++snapshot_.off_track_count;
+  }
+
+  if (has_previous_position_) {
+    update.crossing_detected = isForwardCrossingStartLine(
+      previous_position_, current_position, track_.start_line, track_.forward_hint);
+    if (update.crossing_detected) {
+      update.crossed_lap_time_sec = step_sec - snapshot_.lap_start_step_sec;
+      ++snapshot_.lap_count;
+      snapshot_.last_lap_time_sec = update.crossed_lap_time_sec;
+      if (snapshot_.best_lap_time_sec == 0 ||
+        update.crossed_lap_time_sec < snapshot_.best_lap_time_sec)
+      {
+        snapshot_.best_lap_time_sec = update.crossed_lap_time_sec;
+      }
+      snapshot_.lap_start_step_sec = step_sec;
+    }
+  }
+
+  previous_position_ = current_position;
+  has_previous_position_ = true;
+  update.snapshot = snapshot_;
+  return update;
+}
+
+ProgressSnapshot ProgressTracker::snapshot() const
+{
+  return snapshot_;
+}
+
+}  // namespace race_track

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -1,6 +1,5 @@
 #include <cstdint>
 #include <filesystem>
-#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -12,6 +11,7 @@
 #include "race_interfaces/msg/race_state.hpp"
 #include "race_interfaces/msg/vehicle_race_status.hpp"
 #include "race_track/geometry.hpp"
+#include "race_track/progress_tracker.hpp"
 #include "race_track/track_loader.hpp"
 #include "race_track/track_validator.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -73,6 +73,7 @@ public:
   explicit RaceProgressPublisher(const std::filesystem::path & sample_track_path)
   : Node("race_progress_publisher"),
     track_(loadTrackFromYaml(sample_track_path.string())),
+    progress_tracker_(track_),
     positions_(
       {{-2.0, 0.0}, {-0.5, 0.2}, {1.0, 0.2}, {6.0, 0.1}, {11.0, 0.4}, {18.0, 4.8},
        {9.0, 5.0}, {0.5, 0.0}, {-1.0, 0.0}, {1.5, -0.1}, {4.0, 4.0}})
@@ -93,7 +94,7 @@ public:
       get_logger(), "Loaded track '%s' from %s", track_.track_name.c_str(),
       sample_track_path.c_str());
     RCLCPP_INFO(get_logger(), "Waiting for race commands on /race_command");
-    publishRaceState(currentStepSec());
+    publishRaceState(currentStepSec(), progress_tracker_.snapshot());
   }
 
 private:
@@ -110,37 +111,34 @@ private:
 
     const std::int32_t step_sec = static_cast<std::int32_t>(step_index_);
     const Point2d & current = positions_[step_index_];
-    const std::size_t nearest_index = findNearestCenterlineIndex(track_.centerline, current);
-    const double distance = distanceToCenterline(track_.centerline, current);
-    const bool is_off_track = distance > (track_.track_width / 2.0);
-    if (is_off_track) {
-      ++off_track_count_;
+    ProgressUpdate progress_update = progress_tracker_.update(step_sec, current);
+
+    const bool reached_final_step = (step_index_ + 1U) >= positions_.size();
+    if (reached_final_step) {
+      running_ = false;
+      completed_ = true;
+      progress_tracker_.setHasFinished(true);
+      progress_update.snapshot = progress_tracker_.snapshot();
     }
 
-    bool crossing_detected = false;
-    if (step_index_ > 0U) {
-      crossing_detected = isForwardCrossingStartLine(
-        positions_[step_index_ - 1U], current, track_.start_line, track_.forward_hint);
-      if (crossing_detected) {
-        publishLapEvent(step_sec);
-      }
+    if (progress_update.crossing_detected) {
+      publishLapEvent(step_sec, progress_update);
     }
 
-    publishVehicleRaceStatus(step_sec, is_off_track);
-    publishRaceState(step_sec);
+    publishVehicleRaceStatus(step_sec, progress_update);
+    publishRaceState(step_sec, progress_update.snapshot);
 
     RCLCPP_INFO(
       get_logger(),
       "step=%zu position=(%.3f, %.3f) nearest_centerline_index=%zu distance=%.3f "
       "off_track=%s crossing=%s lap_count=%d off_track_count=%d",
-      step_index_, current.x, current.y, nearest_index, distance, is_off_track ? "true" : "false",
-      crossing_detected ? "true" : "false", lap_count_, off_track_count_);
+      step_index_, current.x, current.y, progress_update.nearest_centerline_index,
+      progress_update.distance_to_centerline, progress_update.is_off_track ? "true" : "false",
+      progress_update.crossing_detected ? "true" : "false", progress_update.snapshot.lap_count,
+      progress_update.snapshot.off_track_count);
 
     ++step_index_;
-    if (step_index_ >= positions_.size()) {
-      running_ = false;
-      completed_ = true;
-      publishRaceState(step_sec);
+    if (reached_final_step) {
       RCLCPP_INFO(get_logger(), "Reached final step, stopping progression");
     }
   }
@@ -155,18 +153,18 @@ private:
         }
         completed_ = false;
         running_ = true;
-        publishRaceState(currentStepSec());
+        publishRaceState(currentStepSec(), progress_tracker_.snapshot());
         RCLCPP_INFO(get_logger(), "Received START command, progression started");
         break;
       case race_interfaces::msg::RaceCommand::STOP:
         running_ = false;
         completed_ = false;
-        publishRaceState(currentStepSec());
+        publishRaceState(currentStepSec(), progress_tracker_.snapshot());
         RCLCPP_INFO(get_logger(), "Received STOP command, progression stopped");
         break;
       case race_interfaces::msg::RaceCommand::RESET:
         resetProgress();
-        publishRaceState(currentStepSec());
+        publishRaceState(currentStepSec(), progress_tracker_.snapshot());
         RCLCPP_INFO(get_logger(), "Received RESET command, progression reset");
         break;
       default:
@@ -180,61 +178,48 @@ private:
     running_ = false;
     completed_ = false;
     step_index_ = 0U;
-    lap_count_ = 0;
-    off_track_count_ = 0;
-    lap_start_step_sec_ = 0;
-    last_lap_time_sec_ = 0;
-    best_lap_time_sec_ = 0;
-    best_lap_time_candidate_sec_ = std::numeric_limits<std::int32_t>::max();
+    progress_tracker_.reset();
   }
 
-  void publishLapEvent(const std::int32_t step_sec)
+  void publishLapEvent(const std::int32_t step_sec, const ProgressUpdate & progress_update)
   {
-    const std::int32_t lap_time_sec = step_sec - lap_start_step_sec_;
-    ++lap_count_;
-    last_lap_time_sec_ = lap_time_sec;
-    if (lap_time_sec < best_lap_time_candidate_sec_) {
-      best_lap_time_candidate_sec_ = lap_time_sec;
-      best_lap_time_sec_ = lap_time_sec;
-    }
-    lap_start_step_sec_ = step_sec;
-
     race_interfaces::msg::LapEvent lap_event;
     lap_event.header.stamp = rclcpp::Time(step_sec, 0U, RCL_ROS_TIME);
     lap_event.header.frame_id = kFrameId;
     lap_event.vehicle_id = kVehicleId;
-    lap_event.lap_count = lap_count_;
-    lap_event.lap_time = makeDuration(lap_time_sec);
-    lap_event.best_lap_time = makeDuration(best_lap_time_sec_);
-    lap_event.has_finished = false;
+    lap_event.lap_count = progress_update.snapshot.lap_count;
+    lap_event.lap_time = makeDuration(progress_update.crossed_lap_time_sec);
+    lap_event.best_lap_time = makeDuration(progress_update.snapshot.best_lap_time_sec);
+    lap_event.has_finished = progress_update.snapshot.has_finished;
     lap_event_publisher_->publish(lap_event);
   }
 
-  void publishRaceState(const std::int32_t step_sec)
+  void publishRaceState(const std::int32_t step_sec, const ProgressSnapshot & snapshot)
   {
     race_interfaces::msg::RaceState race_state;
     race_state.header.stamp = rclcpp::Time(step_sec, 0U, RCL_ROS_TIME);
     race_state.header.frame_id = kFrameId;
     race_state.race_status = currentRaceStatus();
     race_state.elapsed_time = makeDuration(step_sec);
-    race_state.total_laps = lap_count_;
+    race_state.total_laps = snapshot.lap_count;
     race_state_publisher_->publish(race_state);
   }
 
-  void publishVehicleRaceStatus(const std::int32_t step_sec, const bool is_off_track)
+  void publishVehicleRaceStatus(
+    const std::int32_t step_sec, const ProgressUpdate & progress_update)
   {
     race_interfaces::msg::VehicleRaceStatus status;
     status.header.stamp = rclcpp::Time(step_sec, 0U, RCL_ROS_TIME);
     status.header.frame_id = kFrameId;
     status.vehicle_id = kVehicleId;
-    status.lap_count = lap_count_;
-    status.current_lap_time = makeDuration(step_sec - lap_start_step_sec_);
-    status.last_lap_time = makeDuration(last_lap_time_sec_);
-    status.best_lap_time = makeDuration(best_lap_time_sec_);
+    status.lap_count = progress_update.snapshot.lap_count;
+    status.current_lap_time = makeDuration(step_sec - progress_update.snapshot.lap_start_step_sec);
+    status.last_lap_time = makeDuration(progress_update.snapshot.last_lap_time_sec);
+    status.best_lap_time = makeDuration(progress_update.snapshot.best_lap_time_sec);
     status.total_elapsed_time = makeDuration(step_sec);
-    status.has_finished = false;
-    status.is_off_track = is_off_track;
-    status.off_track_count = off_track_count_;
+    status.has_finished = progress_update.snapshot.has_finished;
+    status.is_off_track = progress_update.is_off_track;
+    status.off_track_count = progress_update.snapshot.off_track_count;
     status_publisher_->publish(status);
   }
 
@@ -259,6 +244,7 @@ private:
   }
 
   TrackModel track_;
+  ProgressTracker progress_tracker_;
   std::vector<Point2d> positions_;
   rclcpp::Publisher<race_interfaces::msg::VehicleRaceStatus>::SharedPtr status_publisher_;
   rclcpp::Publisher<race_interfaces::msg::LapEvent>::SharedPtr lap_event_publisher_;
@@ -268,12 +254,6 @@ private:
   bool running_{false};
   bool completed_{false};
   std::size_t step_index_{0U};
-  std::int32_t lap_count_{0};
-  std::int32_t off_track_count_{0};
-  std::int32_t lap_start_step_sec_{0};
-  std::int32_t last_lap_time_sec_{0};
-  std::int32_t best_lap_time_sec_{0};
-  std::int32_t best_lap_time_candidate_sec_{std::numeric_limits<std::int32_t>::max()};
 };
 
 }  // namespace

--- a/src/race_track/test/test_progress_tracker.cpp
+++ b/src/race_track/test/test_progress_tracker.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include "race_track/progress_tracker.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TrackModel makeTrack()
+{
+  TrackModel track;
+  track.track_name = "unit_test_track";
+  track.centerline = {{0.0, 0.0}, {5.0, 0.0}, {10.0, 0.0}};
+  track.track_width = 4.0;
+  track.start_line = {{0.0, -2.0}, {0.0, 2.0}};
+  track.forward_hint = {1.0, 0.0};
+  return track;
+}
+
+TEST(ProgressTrackerTest, UpdatesLapTimingAndOffTrackCount)
+{
+  ProgressTracker tracker(makeTrack());
+
+  const ProgressUpdate first = tracker.update(0, Point2d{-1.0, 0.0});
+  EXPECT_FALSE(first.crossing_detected);
+  EXPECT_FALSE(first.is_off_track);
+  EXPECT_EQ(first.snapshot.lap_count, 0);
+  EXPECT_EQ(first.snapshot.off_track_count, 0);
+
+  const ProgressUpdate second = tracker.update(1, Point2d{1.0, 0.0});
+  EXPECT_TRUE(second.crossing_detected);
+  EXPECT_EQ(second.crossed_lap_time_sec, 1);
+  EXPECT_EQ(second.snapshot.lap_count, 1);
+  EXPECT_EQ(second.snapshot.last_lap_time_sec, 1);
+  EXPECT_EQ(second.snapshot.best_lap_time_sec, 1);
+  EXPECT_EQ(second.snapshot.lap_start_step_sec, 1);
+  EXPECT_FALSE(second.snapshot.has_finished);
+
+  const ProgressUpdate third = tracker.update(2, Point2d{10.0, 3.5});
+  EXPECT_FALSE(third.crossing_detected);
+  EXPECT_TRUE(third.is_off_track);
+  EXPECT_EQ(third.snapshot.off_track_count, 1);
+
+  const ProgressUpdate fourth = tracker.update(3, Point2d{-1.0, 0.0});
+  EXPECT_FALSE(fourth.crossing_detected);
+  EXPECT_EQ(fourth.snapshot.lap_count, 1);
+
+  const ProgressUpdate fifth = tracker.update(4, Point2d{1.0, 0.0});
+  EXPECT_TRUE(fifth.crossing_detected);
+  EXPECT_EQ(fifth.crossed_lap_time_sec, 3);
+  EXPECT_EQ(fifth.snapshot.lap_count, 2);
+  EXPECT_EQ(fifth.snapshot.last_lap_time_sec, 3);
+  EXPECT_EQ(fifth.snapshot.best_lap_time_sec, 1);
+  EXPECT_FALSE(fifth.snapshot.has_finished);
+}
+
+TEST(ProgressTrackerTest, SetHasFinishedUpdatesSnapshotAndResetClearsIt)
+{
+  ProgressTracker tracker(makeTrack());
+
+  tracker.update(0, Point2d{-1.0, 0.0});
+  tracker.setHasFinished(true);
+
+  const ProgressSnapshot finished_snapshot = tracker.snapshot();
+  EXPECT_TRUE(finished_snapshot.has_finished);
+
+  const ProgressUpdate after_finish = tracker.update(1, Point2d{1.0, 0.0});
+  EXPECT_TRUE(after_finish.snapshot.has_finished);
+}
+
+TEST(ProgressTrackerTest, ResetClearsProgressState)
+{
+  ProgressTracker tracker(makeTrack());
+
+  tracker.update(0, Point2d{-1.0, 0.0});
+  tracker.update(1, Point2d{1.0, 0.0});
+  tracker.update(2, Point2d{10.0, 3.5});
+  tracker.reset();
+
+  const ProgressSnapshot snapshot = tracker.snapshot();
+  EXPECT_EQ(snapshot.lap_count, 0);
+  EXPECT_EQ(snapshot.off_track_count, 0);
+  EXPECT_EQ(snapshot.lap_start_step_sec, 0);
+  EXPECT_EQ(snapshot.last_lap_time_sec, 0);
+  EXPECT_EQ(snapshot.best_lap_time_sec, 0);
+  EXPECT_FALSE(snapshot.has_finished);
+
+  const ProgressUpdate after_reset = tracker.update(5, Point2d{1.0, 0.0});
+  EXPECT_FALSE(after_reset.crossing_detected);
+  EXPECT_EQ(after_reset.snapshot.lap_count, 0);
+  EXPECT_EQ(after_reset.snapshot.off_track_count, 0);
+}
+
+}  // namespace
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Extract single-vehicle progress update logic from `race_progress_publisher` into a ROS-independent `ProgressTracker`.

## Changes
- add `ProgressTracker`, `ProgressSnapshot`, and `ProgressUpdate`
- move lap counting, lap timing, crossing detection, and off-track counting out of `race_progress_publisher`
- update `race_progress_publisher` to use tracker output for `RaceState`, `VehicleRaceStatus`, and `LapEvent`
- remove duplicated progress-related internal state from the publisher node
- add unit tests for progress updates, finished flag handling, and reset behavior

## Validation
- `colcon build --packages-select race_track race_interfaces`
- `colcon test --packages-select race_track`
- launched `race_progress_demo.launch.py`
- verified command-driven progression with `start` / `stop` / `reset`
- verified `completed` state is published at the end of the demo progression
- verified `has_finished` is aligned with the final published vehicle status

## Out of scope
- multi-vehicle support
- target lap / finish semantics redesign
- race manager design
- command transport reliability improvements in `race_command_cli`