### PR TITLE
feat: add target lap based completion to single-vehicle demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ROS2 Race Simulator
 ## Minimal Demo
 
 最小 race progress demo は `race_progress_publisher`、`race_progress_monitor`、`race_command_cli` で構成されています。
+single-vehicle demo の完了条件は固定 position 列の終端ではなく、`race_progress_publisher` の `target_lap_count` 到達です。
 build / launch / command / expected behavior は [Milestone 1](docs/milestone1.md) にあります。
 
 ## Docs

--- a/docs/milestone1.md
+++ b/docs/milestone1.md
@@ -231,6 +231,8 @@ source install/setup.bash
 ros2 launch race_track race_progress_demo.launch.py
 ```
 
+この launch は `race_progress_publisher` に `target_lap_count:=2` を渡します。単一車両デモでは、この値に到達した時点で race completion を判定します。
+
 ### Command CLI
 
 もう 1 つ別ターミナルを開き、`race_command_cli` で操作します。
@@ -263,7 +265,8 @@ ros2 run race_track race_command_cli reset
 - launch 直後、monitor に `race_state status=stopped` が表示される
 - `start` 実行後、monitor に `race_state status=running` と `vehicle_race_status` が継続して表示される
 - スタートライン通過時に `lap_event` が表示される
-- 最終 step 到達後、monitor に `race_state status=completed` が表示される
+- `lap_count` が `target_lap_count` に到達した時点で、`vehicle_race_status.has_finished=true` と `race_state status=completed` が揃う
+- `target_lap_count` 未達のまま固定 position 列の終端に到達した場合、publisher は warning を出して停止し、publish される `race_state status=stopped` のまま `completed` には遷移しない
 - `stop` 実行後、monitor に `race_state status=stopped` が表示されて進行が止まる
 - `reset` 実行後、経過時間とラップ数が初期状態に戻り、monitor に `race_state status=stopped` が表示される
 
@@ -275,8 +278,10 @@ ros2 run race_track race_command_cli reset
 
 - 車両は 1 台のみで、`vehicle_id` は固定の `demo_vehicle_1`
 - `race_progress_publisher` は内部の固定 position 列を 1 秒ごとに順番に消費して進行する
+- `race_progress_publisher` は `target_lap_count` パラメータを持ち、デフォルト値は `2`
 - `lap_count` は forward 方向の start line crossing を検出したときだけ増える
-- `completed` / `has_finished` は target laps 判定ではなく、固定 position 列の最終 step に到達したときに立つ
+- `completed` / `has_finished` は `lap_count >= target_lap_count` になったときに立つ
+- 固定 position 列の最終 step 到達だけでは `completed` にならない
 
 状態とフィールドの意味:
 
@@ -284,16 +289,16 @@ ros2 run race_track race_command_cli reset
 | --- | --- |
 | `RaceState.race_status = stopped` | publisher が進行していない状態。初期状態、`stop` 後、`reset` 後がこれに当たる。 |
 | `RaceState.race_status = running` | publisher が固定 position 列を順に消費中の状態。 |
-| `RaceState.race_status = completed` | 固定 position 列の最終 step に到達し、publisher が進行を停止した状態。周回数条件で遷移しているわけではない。 |
+| `RaceState.race_status = completed` | `lap_count >= target_lap_count` が成立し、publisher が進行を停止した状態。 |
 | `VehicleRaceStatus.lap_count` | その車両について、forward 方向の start line crossing が確定した回数。現在の実装では `ProgressTracker` が crossing ごとに `1` ずつ加算する。 |
-| `VehicleRaceStatus.has_finished` | その車両が現在の最小デモの進行を終えたことを表すフラグ。現状では固定 position 列の最終 step 到達時に `true` になり、`reset` で `false` に戻る。 |
-| `RaceState.total_laps` | 現在 publish 時点の `lap_count` を `RaceState` 側にも載せた値。単一車両デモでは実質的に車両 1 台の確定 lap 数と同じで、target laps や race 完了条件の設定値ではない。 |
+| `VehicleRaceStatus.has_finished` | その車両が現在の最小デモで target lap に到達したことを表すフラグ。`lap_count >= target_lap_count` で `true` になり、`reset` で `false` に戻る。 |
+| `RaceState.total_laps` | 現在 publish 時点の `lap_count` を `RaceState` 側にも載せた値。単一車両デモでは実質的に車両 1 台の確定 lap 数と同じで、target lap 設定値そのものではない。 |
 
 補足:
 
 - `LapEvent.lap_count` も crossing 検出後の確定 lap 数を表す
-- `LapEvent.has_finished` は publish 時点の snapshot をそのまま載せるため、現在の実装では通常の lap crossing では `false` のまま
-- 最終 step で `has_finished` は `true` になるが、その step で crossing が発生しない限り、`has_finished=true` の `LapEvent` が必ず出るわけではない
+- `LapEvent.has_finished` は publish 時点の snapshot をそのまま載せるため、target lap に到達した crossing では `true` になる
+- target 未達のまま固定 position 列が尽きた場合、publisher は停止するが `has_finished` は `false` のまま
 
 現時点で未確定なこと:
 
@@ -304,7 +309,7 @@ ros2 run race_track race_command_cli reset
 
 将来の拡張で再整理が必要な点:
 
-- target lap 数を導入する場合、`RaceState.total_laps` という名前は誤解を招くため、意味の再整理または別 field / 別 message の検討が必要
+- 現在は `target_lap_count` を publisher parameter として持つだけなので、multi-vehicle 化や race manager 導入時は設定の置き場を再整理する必要がある
 - finish 条件を高度化する場合、`has_finished` は「デモ終了フラグ」ではなく「レース完了判定」との関係を改めて定義する必要がある
 - multi-vehicle 対応時は、全体 state と各車 state の責務分離を明確にし直す必要がある
 

--- a/src/race_track/launch/race_progress_demo.launch.py
+++ b/src/race_track/launch/race_progress_demo.launch.py
@@ -8,6 +8,7 @@ def generate_launch_description():
             package="race_track",
             executable="race_progress_publisher",
             output="screen",
+            parameters=[{"target_lap_count": 2}],
         ),
         Node(
             package="race_track",

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -74,10 +74,15 @@ public:
   : Node("race_progress_publisher"),
     track_(loadTrackFromYaml(sample_track_path.string())),
     progress_tracker_(track_),
+    target_lap_count_(declare_parameter<std::int64_t>("target_lap_count", 2)),
     positions_(
       {{-2.0, 0.0}, {-0.5, 0.2}, {1.0, 0.2}, {6.0, 0.1}, {11.0, 0.4}, {18.0, 4.8},
        {9.0, 5.0}, {0.5, 0.0}, {-1.0, 0.0}, {1.5, -0.1}, {4.0, 4.0}})
   {
+    if (target_lap_count_ <= 0) {
+      throw std::runtime_error("target_lap_count must be greater than zero");
+    }
+
     validateTrackOrThrow(track_);
 
     status_publisher_ =
@@ -93,6 +98,7 @@ public:
     RCLCPP_INFO(
       get_logger(), "Loaded track '%s' from %s", track_.track_name.c_str(),
       sample_track_path.c_str());
+    RCLCPP_INFO(get_logger(), "Target lap count: %ld", target_lap_count_);
     RCLCPP_INFO(get_logger(), "Waiting for race commands on /race_command");
     publishRaceState(currentStepSec(), progress_tracker_.snapshot());
   }
@@ -100,7 +106,7 @@ public:
 private:
   void onTimer()
   {
-    if (!running_) {
+    if (!running_ || completed_) {
       return;
     }
 
@@ -112,13 +118,19 @@ private:
     const std::int32_t step_sec = static_cast<std::int32_t>(step_index_);
     const Point2d & current = positions_[step_index_];
     ProgressUpdate progress_update = progress_tracker_.update(step_sec, current);
+    const bool target_lap_reached =
+      progress_update.snapshot.lap_count >= static_cast<std::int32_t>(target_lap_count_);
 
-    const bool reached_final_step = (step_index_ + 1U) >= positions_.size();
-    if (reached_final_step) {
+    if (target_lap_reached) {
       running_ = false;
       completed_ = true;
       progress_tracker_.setHasFinished(true);
       progress_update.snapshot = progress_tracker_.snapshot();
+    }
+
+    const bool exhausted_positions = !target_lap_reached && (step_index_ + 1U) >= positions_.size();
+    if (exhausted_positions) {
+      running_ = false;
     }
 
     if (progress_update.crossing_detected) {
@@ -137,18 +149,33 @@ private:
       progress_update.crossing_detected ? "true" : "false", progress_update.snapshot.lap_count,
       progress_update.snapshot.off_track_count);
 
-    ++step_index_;
-    if (reached_final_step) {
-      RCLCPP_INFO(get_logger(), "Reached final step, stopping progression");
+    if (target_lap_reached) {
+      RCLCPP_INFO(
+        get_logger(), "Target lap count reached (%d/%ld), marking race completed",
+        progress_update.snapshot.lap_count, target_lap_count_);
+      return;
     }
+
+    if (exhausted_positions) {
+      running_ = false;
+      RCLCPP_WARN(
+        get_logger(),
+        "Progression stopped at end of fixed positions before reaching target laps (%d/%ld)",
+        progress_update.snapshot.lap_count, target_lap_count_);
+      ++step_index_;
+      return;
+    }
+
+    ++step_index_;
   }
 
   void onRaceCommand(const race_interfaces::msg::RaceCommand::SharedPtr msg)
   {
     switch (msg->command) {
       case race_interfaces::msg::RaceCommand::START:
-        if (step_index_ >= positions_.size()) {
-          RCLCPP_INFO(get_logger(), "Received START at final step, resetting progression first");
+        if (completed_ || step_index_ >= positions_.size()) {
+          RCLCPP_INFO(
+            get_logger(), "Received START after completion or final step, resetting progression first");
           resetProgress();
         }
         completed_ = false;
@@ -254,6 +281,7 @@ private:
   bool running_{false};
   bool completed_{false};
   std::size_t step_index_{0U};
+  std::int64_t target_lap_count_{2};
 };
 
 }  // namespace


### PR DESCRIPTION
## Summary
Add target-lap-based completion to the single-vehicle race progress demo.

## Changes
- add `target_lap_count` parameter to `race_progress_publisher`
- mark the demo as completed when `lap_count >= target_lap_count`
- align `VehicleRaceStatus.has_finished` with target-lap completion
- stop without `completed` if the fixed position sequence ends before reaching the target lap count
- pass `target_lap_count:=2` from `race_progress_demo.launch.py`
- update docs to reflect the new single-vehicle completion semantics

## Validation
- `colcon build --packages-select race_track race_interfaces`
- launched `race_progress_demo.launch.py`
- verified `target_lap_count=2` reaches `race_state status=completed`
- verified `has_finished=true` when target lap is reached
- verified `target_lap_count=99` stops at end of fixed positions with warning
- verified `race_state status=stopped` and `has_finished=false` when target lap is not reached

## Out of scope
- multi-vehicle support
- race manager design
- message definition changes
- advanced finish condition semantics