### PR TITLE
refactor: extract single-vehicle completion policy from publisher

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(race_interfaces REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 add_library(${PROJECT_NAME}
+  src/completion_evaluator.cpp
   src/geometry.cpp
   src/progress_tracker.cpp
   src/track_loader.cpp
@@ -112,6 +113,11 @@ if(BUILD_TESTING)
     test/test_progress_tracker.cpp
   )
   target_link_libraries(test_progress_tracker ${PROJECT_NAME})
+
+  ament_add_gtest(test_completion_evaluator
+    test/test_completion_evaluator.cpp
+  )
+  target_link_libraries(test_completion_evaluator ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)

--- a/src/race_track/include/race_track/completion_evaluator.hpp
+++ b/src/race_track/include/race_track/completion_evaluator.hpp
@@ -1,0 +1,28 @@
+#ifndef RACE_TRACK__COMPLETION_EVALUATOR_HPP_
+#define RACE_TRACK__COMPLETION_EVALUATOR_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "race_track/progress_tracker.hpp"
+
+namespace race_track
+{
+
+struct CompletionDecision
+{
+  bool should_complete{false};
+  bool should_stop_without_completion{false};
+};
+
+class SingleVehicleCompletionEvaluator
+{
+public:
+  CompletionDecision evaluate(
+    const ProgressSnapshot & snapshot, std::size_t step_index, std::size_t position_count,
+    std::int64_t target_lap_count) const;
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__COMPLETION_EVALUATOR_HPP_

--- a/src/race_track/src/completion_evaluator.cpp
+++ b/src/race_track/src/completion_evaluator.cpp
@@ -1,0 +1,26 @@
+#include "race_track/completion_evaluator.hpp"
+
+namespace race_track
+{
+
+CompletionDecision SingleVehicleCompletionEvaluator::evaluate(
+  const ProgressSnapshot & snapshot, const std::size_t step_index, const std::size_t position_count,
+  const std::int64_t target_lap_count) const
+{
+  CompletionDecision decision;
+
+  if (target_lap_count <= 0 || position_count == 0) {
+    return decision;
+  }
+
+  decision.should_complete =
+    snapshot.lap_count >= static_cast<std::int32_t>(target_lap_count);
+
+  if (!decision.should_complete && (step_index + 1U) >= position_count) {
+    decision.should_stop_without_completion = true;
+  }
+
+  return decision;
+}
+
+}  // namespace race_track

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -10,6 +10,7 @@
 #include "race_interfaces/msg/race_command.hpp"
 #include "race_interfaces/msg/race_state.hpp"
 #include "race_interfaces/msg/vehicle_race_status.hpp"
+#include "race_track/completion_evaluator.hpp"
 #include "race_track/geometry.hpp"
 #include "race_track/progress_tracker.hpp"
 #include "race_track/track_loader.hpp"
@@ -118,18 +119,17 @@ private:
     const std::int32_t step_sec = static_cast<std::int32_t>(step_index_);
     const Point2d & current = positions_[step_index_];
     ProgressUpdate progress_update = progress_tracker_.update(step_sec, current);
-    const bool target_lap_reached =
-      progress_update.snapshot.lap_count >= static_cast<std::int32_t>(target_lap_count_);
+    const CompletionDecision decision = completion_evaluator_.evaluate(
+      progress_update.snapshot, step_index_, positions_.size(), target_lap_count_);
 
-    if (target_lap_reached) {
+    if (decision.should_complete) {
       running_ = false;
       completed_ = true;
       progress_tracker_.setHasFinished(true);
       progress_update.snapshot = progress_tracker_.snapshot();
     }
 
-    const bool exhausted_positions = !target_lap_reached && (step_index_ + 1U) >= positions_.size();
-    if (exhausted_positions) {
+    if (decision.should_stop_without_completion) {
       running_ = false;
     }
 
@@ -149,14 +149,14 @@ private:
       progress_update.crossing_detected ? "true" : "false", progress_update.snapshot.lap_count,
       progress_update.snapshot.off_track_count);
 
-    if (target_lap_reached) {
+    if (decision.should_complete) {
       RCLCPP_INFO(
         get_logger(), "Target lap count reached (%d/%ld), marking race completed",
         progress_update.snapshot.lap_count, target_lap_count_);
       return;
     }
 
-    if (exhausted_positions) {
+    if (decision.should_stop_without_completion) {
       running_ = false;
       RCLCPP_WARN(
         get_logger(),
@@ -272,6 +272,7 @@ private:
 
   TrackModel track_;
   ProgressTracker progress_tracker_;
+  SingleVehicleCompletionEvaluator completion_evaluator_;
   std::vector<Point2d> positions_;
   rclcpp::Publisher<race_interfaces::msg::VehicleRaceStatus>::SharedPtr status_publisher_;
   rclcpp::Publisher<race_interfaces::msg::LapEvent>::SharedPtr lap_event_publisher_;

--- a/src/race_track/test/test_completion_evaluator.cpp
+++ b/src/race_track/test/test_completion_evaluator.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "race_track/completion_evaluator.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TEST(CompletionEvaluatorTest, CompletesWhenTargetLapCountReached)
+{
+  SingleVehicleCompletionEvaluator evaluator;
+  ProgressSnapshot snapshot;
+  snapshot.lap_count = 2;
+
+  const CompletionDecision decision = evaluator.evaluate(snapshot, 3U, 10U, 2);
+
+  EXPECT_TRUE(decision.should_complete);
+  EXPECT_FALSE(decision.should_stop_without_completion);
+}
+
+TEST(CompletionEvaluatorTest, StopsWithoutCompletionAtFinalStepWhenTargetNotReached)
+{
+  SingleVehicleCompletionEvaluator evaluator;
+  ProgressSnapshot snapshot;
+  snapshot.lap_count = 1;
+
+  const CompletionDecision decision = evaluator.evaluate(snapshot, 4U, 5U, 2);
+
+  EXPECT_FALSE(decision.should_complete);
+  EXPECT_TRUE(decision.should_stop_without_completion);
+}
+
+TEST(CompletionEvaluatorTest, ContinuesBeforeFinalStepWhenTargetNotReached)
+{
+  SingleVehicleCompletionEvaluator evaluator;
+  ProgressSnapshot snapshot;
+  snapshot.lap_count = 1;
+
+  const CompletionDecision decision = evaluator.evaluate(snapshot, 3U, 5U, 2);
+
+  EXPECT_FALSE(decision.should_complete);
+  EXPECT_FALSE(decision.should_stop_without_completion);
+}
+
+}  // namespace
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Extract single-vehicle completion policy logic from `race_progress_publisher` into a ROS-independent evaluator.

## Changes
- add `SingleVehicleCompletionEvaluator` and `CompletionDecision`
- move target-lap completion / stop-without-completion judgment out of `race_progress_publisher`
- keep `ProgressTracker` focused on progress state updates only
- update `race_progress_publisher` to consume evaluator output for completion handling
- add unit tests for completion evaluator behavior

## Validation
- `colcon build --packages-select race_track race_interfaces`
- `colcon test --packages-select race_track`
- verified target-lap completion still reaches `race_state status=completed`
- verified target-lap miss at fixed-position end still stops with `race_state status=stopped`

## Out of scope
- multi-vehicle support
- race manager node design
- message definition changes
- target lap configuration redesign
- advanced finish condition semantics