### PR TITLE
docs: add development validation and review checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ build / launch / command / expected behavior は [Milestone 1](docs/milestone1.m
 
 ## Docs
 
+- [Development Validation](docs/dev_validation.md)
+- [Review Checklist](docs/review_checklist.md)
 - [Milestone 1](docs/milestone1.md)

--- a/docs/dev_validation.md
+++ b/docs/dev_validation.md
@@ -1,0 +1,233 @@
+# Development Validation
+
+current single-vehicle demo を前提にした開発用の最小 validation 手順です。
+対象は `race_progress_publisher`、`race_progress_monitor`、`race_command_cli` の組み合わせです。
+
+## Scope
+
+- `ros2 launch race_track race_progress_demo.launch.py` を使う current demo の確認に限定する
+- 完了条件は固定 position 列の終端ではなく `target_lap_count=2` 到達とする
+- 実装に存在しない運用や将来構成はここに持ち込まない
+
+## Clean Start
+
+まず既存の demo プロセスが残っていない状態から始めます。
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 node list
+```
+
+期待:
+
+- `race_progress_publisher`
+- `race_progress_monitor`
+
+上の 2 ノードが出ていないこと。
+
+残っている場合は、起動しているターミナルで `Ctrl-C` してから再確認します。
+どのターミナルが残しているか分からない場合だけ、次で親プロセスを確認します。
+
+```bash
+ps -ef | grep -E 'race_progress_demo.launch.py|race_progress_publisher|race_progress_monitor' | grep -v grep
+```
+
+## Build
+
+ワークスペース直下で実行します。
+
+```bash
+source /opt/ros/jazzy/setup.bash
+colcon build --packages-select race_track race_interfaces
+source install/setup.bash
+```
+
+確認ポイント:
+
+- `race_interfaces` と `race_track` が build 対象に入る
+- build 完了後に `source install/setup.bash` をやり直す
+
+## Minimal Demo
+
+### 1. Launch
+
+ターミナル A:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 launch race_track race_progress_demo.launch.py
+```
+
+起動直後の期待:
+
+- publisher 側に `Target lap count: 2`
+- publisher 側に `Waiting for race commands on /race_command`
+- monitor 側に `Monitoring /race_state, /vehicle_race_status, and /lap_event`
+- monitor 側に `race_state status=stopped`
+
+### 2. Start
+
+ターミナル B:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 run race_track race_command_cli start
+```
+
+期待:
+
+- CLI 側に `sent START`
+- monitor 側に `race_state status=running`
+- monitor 側に `vehicle_race_status vehicle_id=demo_vehicle_1 ...`
+
+### 3. Stop / Reset
+
+停止確認:
+
+```bash
+ros2 run race_track race_command_cli stop
+```
+
+期待:
+
+- monitor 側に `race_state status=stopped`
+- 以後 `vehicle_race_status` の更新が止まる
+
+リセット確認:
+
+```bash
+ros2 run race_track race_command_cli reset
+```
+
+期待:
+
+- monitor 側に `race_state status=stopped`
+- `lap_count` と経過時間が初期状態に戻る
+
+## Target Lap Completion
+
+`target_lap_count=2` 到達を確認する最小手順です。
+
+ターミナル A:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 launch race_track race_progress_demo.launch.py
+```
+
+ターミナル B:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 run race_track race_command_cli start
+```
+
+monitor 側の期待:
+
+- スタートライン通過時に `lap_event`
+- `lap_count=1` の後も `race_state status=running`
+- `lap_count=2` 到達時に `vehicle_race_status ... has_finished=true`
+- 同じタイミングで `race_state status=completed`
+
+補足:
+
+- fixed position 列の終端に着いたこと自体は完了条件ではない
+- `completed` は `lap_count >= target_lap_count` のときだけ成立する
+
+## Quick Checks
+
+launch 後に別ターミナルで必要最小限の接続状態だけ見たい場合:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 node list
+ros2 topic info /race_command -v
+```
+
+期待:
+
+- `ros2 node list` に `race_progress_publisher` と `race_progress_monitor`
+- `/race_command` の subscriber に `race_progress_publisher`
+
+注記:
+
+- `ros2 topic echo --no-daemon /race_state --once` は「これから来る 1 件」を待つため、観測タイミングによっては何も出ず、接続確認用途としては不安定
+
+## Troubleshooting
+
+### `race_command_cli` で `no subscribers connected to /race_command before publish` が出る
+
+確認:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 topic info /race_command -v
+```
+
+見る点:
+
+- subscriber が 0 の場合、publisher が未起動か `source install/setup.bash` 漏れ
+- launch 直後なら 1 秒待ってから再実行する
+
+### monitor に何も流れない
+
+確認:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 topic echo --no-daemon /race_state --once
+ros2 topic echo --no-daemon /vehicle_race_status --once
+```
+
+見る点:
+
+- `/race_state` が来るのに monitor が無反応なら monitor 側プロセス異常を疑う
+- `/vehicle_race_status` が来ない場合は `start` 未送信か publisher 側ログを確認する
+
+### node 重複で挙動が読めない
+
+確認:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 node list
+ps -ef | grep -E 'race_progress_demo.launch.py|race_progress_publisher|race_progress_monitor' | grep -v grep
+```
+
+見る点:
+
+- 同じ demo を複数ターミナルで launch していないか
+- `Ctrl-C` 後も親 launch か node が残っていないか
+
+対処:
+
+- 残っているターミナルを止める
+- 状態が分からなくなったら clean start からやり直す
+
+## Cleanup
+
+通常は launch しているターミナル A で `Ctrl-C` します。
+
+終了確認:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 node list
+```
+
+期待:
+
+- `race_progress_publisher`
+- `race_progress_monitor`
+
+上の 2 ノードが消えていること。

--- a/docs/review_checklist.md
+++ b/docs/review_checklist.md
@@ -1,0 +1,59 @@
+# Review Checklist
+
+PR 前の review 観点を固定するための checklist です。
+current single-vehicle demo を前提に、`実装PR` と `docs PR` を分けて使います。
+
+## 実装PR
+
+### Scope
+
+- 変更内容が current single-vehicle demo の前提を壊していない
+- 実装以上の仕様を docs や PR description で主張していない
+- 変更スコープ外の挙動を暗黙に変えていない
+
+### Build And Validation
+
+- `colcon build --packages-select race_track race_interfaces` が通る
+- `source install/setup.bash` 後に demo を起動している
+- `ros2 launch race_track race_progress_demo.launch.py` で起動できる
+- `ros2 run race_track race_command_cli start` で進行開始する
+- `ros2 run race_track race_command_cli stop` で停止する
+- `ros2 run race_track race_command_cli reset` で初期状態に戻る
+- `target_lap_count=2` 到達時に `race_state status=completed` と `has_finished=true` が揃う
+
+### Behavior
+
+- `/race_command` の publish-subscribe 関係が崩れていない
+- `/race_state` と `/vehicle_race_status` の最低限の観測ができる
+- node 重複や stale process があるときの挙動悪化を招いていない
+- current demo の完了条件を fixed position 列の終端に戻していない
+
+### Review Focus
+
+- node 名、topic 名、message 型の変更は必要性が説明されている
+- single-vehicle 前提の固定値を変えた場合、影響範囲が明示されている
+- ログや状態遷移の変更が validation 手順で追える
+- 手元確認で使ったコマンドと観測結果が PR description にある
+- 必要なテスト追加や既存テスト更新が漏れていない
+
+## docs PR
+
+### Scope
+
+- docs が current single-vehicle demo の実装範囲に収まっている
+- 将来仕様や未実装機能を事実のように書いていない
+- 実装変更なしで成立する記述だけにしている
+
+### Accuracy
+
+- build / launch / command のコマンドがそのままコピペできる
+- package 名、launch 名、node 名、topic 名が実装と一致する
+- `target_lap_count=2` と完了条件の説明が実装と一致する
+- troubleshooting の切り分け手順が実装済みの観測手段に限定されている
+
+### Maintainability
+
+- 長すぎず、普段の開発で参照しやすい粒度になっている
+- 手順と checklist が重複しすぎていない
+- README への追記がある場合は導線だけに留めている
+- 大規模な仕様整理や README 全面更新を混ぜていない


### PR DESCRIPTION
## Summary
Add practical development docs for validation workflow and pre-PR review.

## Changes
- add `docs/dev_validation.md` for clean start, build, launch, command, validation, troubleshooting, and cleanup
- add `docs/review_checklist.md` for implementation PR and docs PR review points
- add README links to the new development docs

## Validation
- docs-only change
- reviewed against the current single-vehicle demo workflow and recent validation/debugging patterns

## Out of scope
- code changes
- script automation
- CI changes
- launch/runtime behavior changes