### PR TITLE
refactor: extract race state assembly from publisher

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(${PROJECT_NAME}
   src/completion_evaluator.cpp
   src/geometry.cpp
   src/progress_tracker.cpp
+  src/race_state_assembler.cpp
   src/track_loader.cpp
   src/track_validator.cpp
 )
@@ -18,6 +19,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp)
+ament_target_dependencies(${PROJECT_NAME} race_interfaces)
 
 add_executable(track_demo
   src/track_demo.cpp
@@ -118,9 +120,15 @@ if(BUILD_TESTING)
     test/test_completion_evaluator.cpp
   )
   target_link_libraries(test_completion_evaluator ${PROJECT_NAME})
+
+  ament_add_gtest(test_race_state_assembler
+    test/test_race_state_assembler.cpp
+  )
+  target_link_libraries(test_race_state_assembler ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)
+ament_export_dependencies(race_interfaces)
 ament_export_dependencies(yaml-cpp)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 

--- a/src/race_track/include/race_track/race_state_assembler.hpp
+++ b/src/race_track/include/race_track/race_state_assembler.hpp
@@ -1,0 +1,23 @@
+#ifndef RACE_TRACK__RACE_STATE_ASSEMBLER_HPP_
+#define RACE_TRACK__RACE_STATE_ASSEMBLER_HPP_
+
+#include <cstdint>
+#include <string>
+
+#include "race_interfaces/msg/race_state.hpp"
+#include "race_track/progress_tracker.hpp"
+
+namespace race_track
+{
+
+class RaceStateAssembler
+{
+public:
+  race_interfaces::msg::RaceState assemble(
+    const std::string & race_status, std::int32_t step_sec,
+    const ProgressSnapshot & snapshot) const;
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__RACE_STATE_ASSEMBLER_HPP_

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -13,6 +13,7 @@
 #include "race_track/completion_evaluator.hpp"
 #include "race_track/geometry.hpp"
 #include "race_track/progress_tracker.hpp"
+#include "race_track/race_state_assembler.hpp"
 #include "race_track/track_loader.hpp"
 #include "race_track/track_validator.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -24,7 +25,6 @@ namespace
 
 constexpr char kVehicleId[] = "demo_vehicle_1";
 constexpr char kFrameId[] = "map";
-
 std::filesystem::path getExecutableDir(const char * argv0)
 {
   if (argv0 == nullptr) {
@@ -223,12 +223,8 @@ private:
 
   void publishRaceState(const std::int32_t step_sec, const ProgressSnapshot & snapshot)
   {
-    race_interfaces::msg::RaceState race_state;
-    race_state.header.stamp = rclcpp::Time(step_sec, 0U, RCL_ROS_TIME);
-    race_state.header.frame_id = kFrameId;
-    race_state.race_status = currentRaceStatus();
-    race_state.elapsed_time = makeDuration(step_sec);
-    race_state.completed_laps = snapshot.lap_count;
+    race_interfaces::msg::RaceState race_state =
+      race_state_assembler_.assemble(currentRaceStatus(), step_sec, snapshot);
     race_state_publisher_->publish(race_state);
   }
 
@@ -273,6 +269,7 @@ private:
   TrackModel track_;
   ProgressTracker progress_tracker_;
   SingleVehicleCompletionEvaluator completion_evaluator_;
+  RaceStateAssembler race_state_assembler_;
   std::vector<Point2d> positions_;
   rclcpp::Publisher<race_interfaces::msg::VehicleRaceStatus>::SharedPtr status_publisher_;
   rclcpp::Publisher<race_interfaces::msg::LapEvent>::SharedPtr lap_event_publisher_;

--- a/src/race_track/src/race_state_assembler.cpp
+++ b/src/race_track/src/race_state_assembler.cpp
@@ -1,0 +1,36 @@
+#include "race_track/race_state_assembler.hpp"
+
+#include "builtin_interfaces/msg/duration.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+constexpr char kFrameId[] = "map";
+
+builtin_interfaces::msg::Duration makeDuration(const std::int32_t seconds)
+{
+  builtin_interfaces::msg::Duration duration;
+  duration.sec = seconds;
+  duration.nanosec = 0U;
+  return duration;
+}
+
+}  // namespace
+
+race_interfaces::msg::RaceState RaceStateAssembler::assemble(
+  const std::string & race_status, const std::int32_t step_sec,
+  const ProgressSnapshot & snapshot) const
+{
+  race_interfaces::msg::RaceState race_state;
+  race_state.header.stamp.sec = step_sec;
+  race_state.header.stamp.nanosec = 0U;
+  race_state.header.frame_id = kFrameId;
+  race_state.race_status = race_status;
+  race_state.elapsed_time = makeDuration(step_sec);
+  race_state.completed_laps = snapshot.lap_count;
+  return race_state;
+}
+
+}  // namespace race_track

--- a/src/race_track/test/test_race_state_assembler.cpp
+++ b/src/race_track/test/test_race_state_assembler.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+#include "race_track/progress_tracker.hpp"
+#include "race_track/race_state_assembler.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TEST(RaceStateAssemblerTest, AssemblesRaceStateFromMinimalInputs)
+{
+  RaceStateAssembler assembler;
+  ProgressSnapshot snapshot;
+  snapshot.lap_count = 3;
+  snapshot.off_track_count = 2;
+  snapshot.has_finished = true;
+
+  const auto race_state = assembler.assemble("completed", 17, snapshot);
+
+  EXPECT_EQ(race_state.header.stamp.sec, 17);
+  EXPECT_EQ(race_state.header.stamp.nanosec, 0U);
+  EXPECT_EQ(race_state.header.frame_id, "map");
+  EXPECT_EQ(race_state.race_status, "completed");
+  EXPECT_EQ(race_state.elapsed_time.sec, 17);
+  EXPECT_EQ(race_state.elapsed_time.nanosec, 0U);
+  EXPECT_EQ(race_state.completed_laps, 3);
+}
+
+}  // namespace
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Extract `RaceState` message assembly from `race_progress_publisher` into a dedicated assembler.

## Changes
- add `RaceStateAssembler` for assembling `race_interfaces::msg::RaceState`
- move `RaceState` message construction out of `race_progress_publisher`
- keep race status decision logic in the publisher
- add unit test for race state assembly
- update `race_track` library/test targets for the new assembler

## Validation
- `colcon build --packages-select race_track race_interfaces`
- `colcon test --packages-select race_track`
- launched `race_progress_demo.launch.py`
- verified `race_state status=running` during progression
- verified `race_state status=completed elapsed=9.0 completed_laps=2` at target lap completion

## Out of scope
- `VehicleRaceStatus` assembly extraction
- `LapEvent` assembly extraction
- message definition changes
- completion policy changes
- multi-vehicle support