### PR TITLE
refactor: extract vehicle race status assembly from publisher

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(${PROJECT_NAME}
   src/race_state_assembler.cpp
   src/track_loader.cpp
   src/track_validator.cpp
+  src/vehicle_race_status_assembler.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -125,6 +126,11 @@ if(BUILD_TESTING)
     test/test_race_state_assembler.cpp
   )
   target_link_libraries(test_race_state_assembler ${PROJECT_NAME})
+
+  ament_add_gtest(test_vehicle_race_status_assembler
+    test/test_vehicle_race_status_assembler.cpp
+  )
+  target_link_libraries(test_vehicle_race_status_assembler ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)

--- a/src/race_track/include/race_track/vehicle_race_status_assembler.hpp
+++ b/src/race_track/include/race_track/vehicle_race_status_assembler.hpp
@@ -1,0 +1,23 @@
+#ifndef RACE_TRACK__VEHICLE_RACE_STATUS_ASSEMBLER_HPP_
+#define RACE_TRACK__VEHICLE_RACE_STATUS_ASSEMBLER_HPP_
+
+#include <cstdint>
+#include <string>
+
+#include "race_interfaces/msg/vehicle_race_status.hpp"
+#include "race_track/progress_tracker.hpp"
+
+namespace race_track
+{
+
+class VehicleRaceStatusAssembler
+{
+public:
+  race_interfaces::msg::VehicleRaceStatus assemble(
+    std::int32_t step_sec, const std::string & vehicle_id,
+    const ProgressUpdate & progress_update) const;
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__VEHICLE_RACE_STATUS_ASSEMBLER_HPP_

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -16,6 +16,7 @@
 #include "race_track/race_state_assembler.hpp"
 #include "race_track/track_loader.hpp"
 #include "race_track/track_validator.hpp"
+#include "race_track/vehicle_race_status_assembler.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 namespace race_track
@@ -231,19 +232,8 @@ private:
   void publishVehicleRaceStatus(
     const std::int32_t step_sec, const ProgressUpdate & progress_update)
   {
-    race_interfaces::msg::VehicleRaceStatus status;
-    status.header.stamp = rclcpp::Time(step_sec, 0U, RCL_ROS_TIME);
-    status.header.frame_id = kFrameId;
-    status.vehicle_id = kVehicleId;
-    status.lap_count = progress_update.snapshot.lap_count;
-    status.current_lap_time = makeDuration(step_sec - progress_update.snapshot.lap_start_step_sec);
-    status.last_lap_time = makeDuration(progress_update.snapshot.last_lap_time_sec);
-    status.best_lap_time = makeDuration(progress_update.snapshot.best_lap_time_sec);
-    status.total_elapsed_time = makeDuration(step_sec);
-    status.has_finished = progress_update.snapshot.has_finished;
-    status.is_off_track = progress_update.is_off_track;
-    status.off_track_count = progress_update.snapshot.off_track_count;
-    status_publisher_->publish(status);
+    status_publisher_->publish(
+      vehicle_race_status_assembler_.assemble(step_sec, kVehicleId, progress_update));
   }
 
   std::int32_t currentStepSec() const
@@ -270,6 +260,7 @@ private:
   ProgressTracker progress_tracker_;
   SingleVehicleCompletionEvaluator completion_evaluator_;
   RaceStateAssembler race_state_assembler_;
+  VehicleRaceStatusAssembler vehicle_race_status_assembler_;
   std::vector<Point2d> positions_;
   rclcpp::Publisher<race_interfaces::msg::VehicleRaceStatus>::SharedPtr status_publisher_;
   rclcpp::Publisher<race_interfaces::msg::LapEvent>::SharedPtr lap_event_publisher_;

--- a/src/race_track/src/vehicle_race_status_assembler.cpp
+++ b/src/race_track/src/vehicle_race_status_assembler.cpp
@@ -1,0 +1,42 @@
+#include "race_track/vehicle_race_status_assembler.hpp"
+
+#include "builtin_interfaces/msg/duration.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+constexpr char kFrameId[] = "map";
+
+builtin_interfaces::msg::Duration makeDuration(const std::int32_t seconds)
+{
+  builtin_interfaces::msg::Duration duration;
+  duration.sec = seconds;
+  duration.nanosec = 0U;
+  return duration;
+}
+
+}  // namespace
+
+race_interfaces::msg::VehicleRaceStatus VehicleRaceStatusAssembler::assemble(
+  const std::int32_t step_sec, const std::string & vehicle_id,
+  const ProgressUpdate & progress_update) const
+{
+  race_interfaces::msg::VehicleRaceStatus status;
+  status.header.stamp.sec = step_sec;
+  status.header.stamp.nanosec = 0U;
+  status.header.frame_id = kFrameId;
+  status.vehicle_id = vehicle_id;
+  status.lap_count = progress_update.snapshot.lap_count;
+  status.current_lap_time = makeDuration(step_sec - progress_update.snapshot.lap_start_step_sec);
+  status.last_lap_time = makeDuration(progress_update.snapshot.last_lap_time_sec);
+  status.best_lap_time = makeDuration(progress_update.snapshot.best_lap_time_sec);
+  status.total_elapsed_time = makeDuration(step_sec);
+  status.has_finished = progress_update.snapshot.has_finished;
+  status.is_off_track = progress_update.is_off_track;
+  status.off_track_count = progress_update.snapshot.off_track_count;
+  return status;
+}
+
+}  // namespace race_track

--- a/src/race_track/test/test_vehicle_race_status_assembler.cpp
+++ b/src/race_track/test/test_vehicle_race_status_assembler.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include "race_track/progress_tracker.hpp"
+#include "race_track/vehicle_race_status_assembler.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TEST(VehicleRaceStatusAssemblerTest, AssemblesVehicleRaceStatusFromMinimalInputs)
+{
+  VehicleRaceStatusAssembler assembler;
+  ProgressUpdate progress_update;
+  progress_update.snapshot.lap_count = 2;
+  progress_update.snapshot.off_track_count = 3;
+  progress_update.snapshot.lap_start_step_sec = 8;
+  progress_update.snapshot.last_lap_time_sec = 11;
+  progress_update.snapshot.best_lap_time_sec = 9;
+  progress_update.snapshot.has_finished = true;
+  progress_update.is_off_track = true;
+
+  const auto status = assembler.assemble(17, "demo_vehicle_1", progress_update);
+
+  EXPECT_EQ(status.header.stamp.sec, 17);
+  EXPECT_EQ(status.header.stamp.nanosec, 0U);
+  EXPECT_EQ(status.header.frame_id, "map");
+  EXPECT_EQ(status.vehicle_id, "demo_vehicle_1");
+  EXPECT_EQ(status.lap_count, 2);
+  EXPECT_EQ(status.current_lap_time.sec, 9);
+  EXPECT_EQ(status.current_lap_time.nanosec, 0U);
+  EXPECT_EQ(status.last_lap_time.sec, 11);
+  EXPECT_EQ(status.last_lap_time.nanosec, 0U);
+  EXPECT_EQ(status.best_lap_time.sec, 9);
+  EXPECT_EQ(status.best_lap_time.nanosec, 0U);
+  EXPECT_EQ(status.total_elapsed_time.sec, 17);
+  EXPECT_EQ(status.total_elapsed_time.nanosec, 0U);
+  EXPECT_TRUE(status.has_finished);
+  EXPECT_TRUE(status.is_off_track);
+  EXPECT_EQ(status.off_track_count, 3);
+}
+
+}  // namespace
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Extract `VehicleRaceStatus` message assembly from `race_progress_publisher` into a dedicated assembler.

## Changes
- add `VehicleRaceStatusAssembler` for assembling `race_interfaces::msg::VehicleRaceStatus`
- move `VehicleRaceStatus` message construction out of `race_progress_publisher`
- keep progress update and completion policy logic in the publisher
- add unit test for vehicle race status assembly
- update `race_track` library/test targets for the new assembler

## Validation
- `colcon build --packages-select race_track race_interfaces`
- `colcon test --packages-select race_track`
- launched `race_progress_demo.launch.py`
- verified race progress still starts and publishes vehicle status during progression
- verified target-lap completion behavior remains unchanged

## Out of scope
- `LapEvent` assembly extraction
- `RaceState` assembly changes
- message definition changes
- completion policy changes
- multi-vehicle support