### PR TITLE
refactor: extract lap event assembly from publisher

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(yaml-cpp REQUIRED)
 add_library(${PROJECT_NAME}
   src/completion_evaluator.cpp
   src/geometry.cpp
+  src/lap_event_assembler.cpp
   src/progress_tracker.cpp
   src/race_state_assembler.cpp
   src/track_loader.cpp
@@ -126,6 +127,11 @@ if(BUILD_TESTING)
     test/test_race_state_assembler.cpp
   )
   target_link_libraries(test_race_state_assembler ${PROJECT_NAME})
+
+  ament_add_gtest(test_lap_event_assembler
+    test/test_lap_event_assembler.cpp
+  )
+  target_link_libraries(test_lap_event_assembler ${PROJECT_NAME})
 
   ament_add_gtest(test_vehicle_race_status_assembler
     test/test_vehicle_race_status_assembler.cpp

--- a/src/race_track/include/race_track/lap_event_assembler.hpp
+++ b/src/race_track/include/race_track/lap_event_assembler.hpp
@@ -1,0 +1,23 @@
+#ifndef RACE_TRACK__LAP_EVENT_ASSEMBLER_HPP_
+#define RACE_TRACK__LAP_EVENT_ASSEMBLER_HPP_
+
+#include <cstdint>
+#include <string>
+
+#include "race_interfaces/msg/lap_event.hpp"
+#include "race_track/progress_tracker.hpp"
+
+namespace race_track
+{
+
+class LapEventAssembler
+{
+public:
+  race_interfaces::msg::LapEvent assemble(
+    std::int32_t step_sec, const std::string & vehicle_id,
+    const ProgressUpdate & progress_update) const;
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__LAP_EVENT_ASSEMBLER_HPP_

--- a/src/race_track/src/lap_event_assembler.cpp
+++ b/src/race_track/src/lap_event_assembler.cpp
@@ -1,0 +1,38 @@
+#include "race_track/lap_event_assembler.hpp"
+
+#include "builtin_interfaces/msg/duration.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+constexpr char kFrameId[] = "map";
+
+builtin_interfaces::msg::Duration makeDuration(const std::int32_t seconds)
+{
+  builtin_interfaces::msg::Duration duration;
+  duration.sec = seconds;
+  duration.nanosec = 0U;
+  return duration;
+}
+
+}  // namespace
+
+race_interfaces::msg::LapEvent LapEventAssembler::assemble(
+  const std::int32_t step_sec, const std::string & vehicle_id,
+  const ProgressUpdate & progress_update) const
+{
+  race_interfaces::msg::LapEvent lap_event;
+  lap_event.header.stamp.sec = step_sec;
+  lap_event.header.stamp.nanosec = 0U;
+  lap_event.header.frame_id = kFrameId;
+  lap_event.vehicle_id = vehicle_id;
+  lap_event.lap_count = progress_update.snapshot.lap_count;
+  lap_event.lap_time = makeDuration(progress_update.crossed_lap_time_sec);
+  lap_event.best_lap_time = makeDuration(progress_update.snapshot.best_lap_time_sec);
+  lap_event.has_finished = progress_update.snapshot.has_finished;
+  return lap_event;
+}
+
+}  // namespace race_track

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -5,13 +5,13 @@
 #include <string>
 #include <vector>
 
-#include "builtin_interfaces/msg/duration.hpp"
 #include "race_interfaces/msg/lap_event.hpp"
 #include "race_interfaces/msg/race_command.hpp"
 #include "race_interfaces/msg/race_state.hpp"
 #include "race_interfaces/msg/vehicle_race_status.hpp"
 #include "race_track/completion_evaluator.hpp"
 #include "race_track/geometry.hpp"
+#include "race_track/lap_event_assembler.hpp"
 #include "race_track/progress_tracker.hpp"
 #include "race_track/race_state_assembler.hpp"
 #include "race_track/track_loader.hpp"
@@ -25,7 +25,6 @@ namespace
 {
 
 constexpr char kVehicleId[] = "demo_vehicle_1";
-constexpr char kFrameId[] = "map";
 std::filesystem::path getExecutableDir(const char * argv0)
 {
   if (argv0 == nullptr) {
@@ -59,14 +58,6 @@ std::filesystem::path resolveSampleTrackPath(const char * argv0)
   }
 
   throw std::runtime_error("Failed to locate config/sample_track.yaml");
-}
-
-builtin_interfaces::msg::Duration makeDuration(const std::int32_t seconds)
-{
-  builtin_interfaces::msg::Duration duration;
-  duration.sec = seconds;
-  duration.nanosec = 0U;
-  return duration;
 }
 
 class RaceProgressPublisher : public rclcpp::Node
@@ -211,15 +202,8 @@ private:
 
   void publishLapEvent(const std::int32_t step_sec, const ProgressUpdate & progress_update)
   {
-    race_interfaces::msg::LapEvent lap_event;
-    lap_event.header.stamp = rclcpp::Time(step_sec, 0U, RCL_ROS_TIME);
-    lap_event.header.frame_id = kFrameId;
-    lap_event.vehicle_id = kVehicleId;
-    lap_event.lap_count = progress_update.snapshot.lap_count;
-    lap_event.lap_time = makeDuration(progress_update.crossed_lap_time_sec);
-    lap_event.best_lap_time = makeDuration(progress_update.snapshot.best_lap_time_sec);
-    lap_event.has_finished = progress_update.snapshot.has_finished;
-    lap_event_publisher_->publish(lap_event);
+    lap_event_publisher_->publish(
+      lap_event_assembler_.assemble(step_sec, kVehicleId, progress_update));
   }
 
   void publishRaceState(const std::int32_t step_sec, const ProgressSnapshot & snapshot)
@@ -259,6 +243,7 @@ private:
   TrackModel track_;
   ProgressTracker progress_tracker_;
   SingleVehicleCompletionEvaluator completion_evaluator_;
+  LapEventAssembler lap_event_assembler_;
   RaceStateAssembler race_state_assembler_;
   VehicleRaceStatusAssembler vehicle_race_status_assembler_;
   std::vector<Point2d> positions_;

--- a/src/race_track/test/test_lap_event_assembler.cpp
+++ b/src/race_track/test/test_lap_event_assembler.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+#include "race_track/lap_event_assembler.hpp"
+#include "race_track/progress_tracker.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TEST(LapEventAssemblerTest, AssemblesLapEventFromMinimalInputs)
+{
+  LapEventAssembler assembler;
+  ProgressUpdate progress_update;
+  progress_update.snapshot.lap_count = 2;
+  progress_update.snapshot.best_lap_time_sec = 9;
+  progress_update.snapshot.has_finished = true;
+  progress_update.crossed_lap_time_sec = 11;
+
+  const auto lap_event = assembler.assemble(17, "demo_vehicle_1", progress_update);
+
+  EXPECT_EQ(lap_event.header.stamp.sec, 17);
+  EXPECT_EQ(lap_event.header.stamp.nanosec, 0U);
+  EXPECT_EQ(lap_event.header.frame_id, "map");
+  EXPECT_EQ(lap_event.vehicle_id, "demo_vehicle_1");
+  EXPECT_EQ(lap_event.lap_count, 2);
+  EXPECT_EQ(lap_event.lap_time.sec, 11);
+  EXPECT_EQ(lap_event.lap_time.nanosec, 0U);
+  EXPECT_EQ(lap_event.best_lap_time.sec, 9);
+  EXPECT_EQ(lap_event.best_lap_time.nanosec, 0U);
+  EXPECT_TRUE(lap_event.has_finished);
+}
+
+}  // namespace
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Extract `LapEvent` message assembly from `race_progress_publisher` into a dedicated assembler.

## Changes
- add `LapEventAssembler` for assembling `race_interfaces::msg::LapEvent`
- move `LapEvent` message construction out of `race_progress_publisher`
- keep crossing detection and publish timing in the publisher
- add unit test for lap event assembly
- update `race_track` library/test targets for the new assembler

## Validation
- `colcon build --packages-select race_track race_interfaces`
- `colcon test --packages-select race_track`
- launched `race_progress_demo.launch.py`
- verified race progress still starts and publishes lap events on crossing
- verified target-lap completion behavior remains unchanged

## Out of scope
- message definition changes
- completion policy changes
- multi-vehicle support
- launch / CLI changes