### PR TITLE
refactor: extract single vehicle runtime from publisher

### DIFF
--- a/src/race_track/CMakeLists.txt
+++ b/src/race_track/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(${PROJECT_NAME}
   src/lap_event_assembler.cpp
   src/progress_tracker.cpp
   src/race_state_assembler.cpp
+  src/single_vehicle_runtime.cpp
   src/track_loader.cpp
   src/track_validator.cpp
   src/vehicle_race_status_assembler.cpp
@@ -137,6 +138,11 @@ if(BUILD_TESTING)
     test/test_vehicle_race_status_assembler.cpp
   )
   target_link_libraries(test_vehicle_race_status_assembler ${PROJECT_NAME})
+
+  ament_add_gtest(test_single_vehicle_runtime
+    test/test_single_vehicle_runtime.cpp
+  )
+  target_link_libraries(test_single_vehicle_runtime ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)

--- a/src/race_track/include/race_track/single_vehicle_runtime.hpp
+++ b/src/race_track/include/race_track/single_vehicle_runtime.hpp
@@ -1,0 +1,59 @@
+#ifndef RACE_TRACK__SINGLE_VEHICLE_RUNTIME_HPP_
+#define RACE_TRACK__SINGLE_VEHICLE_RUNTIME_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "race_track/completion_evaluator.hpp"
+#include "race_track/geometry.hpp"
+#include "race_track/progress_tracker.hpp"
+#include "race_track/track_model.hpp"
+
+namespace race_track
+{
+
+struct SingleVehicleTickResult
+{
+  bool advanced{false};
+  bool crossing_detected{false};
+  bool just_completed{false};
+  bool stopped_without_completion{false};
+  std::int32_t step_sec{0};
+  Point2d current_position{};
+  ProgressUpdate progress_update{};
+};
+
+class SingleVehicleRuntime
+{
+public:
+  SingleVehicleRuntime(
+    const TrackModel & track, std::vector<Point2d> positions, std::int64_t target_lap_count);
+
+  bool start();
+  bool stop();
+  void reset();
+
+  SingleVehicleTickResult tick();
+
+  bool running() const;
+  bool completed() const;
+  std::size_t step_index() const;
+  std::int32_t current_step_sec() const;
+  std::string current_race_status() const;
+  ProgressSnapshot snapshot() const;
+
+private:
+  ProgressTracker progress_tracker_;
+  SingleVehicleCompletionEvaluator completion_evaluator_;
+  std::vector<Point2d> positions_;
+  std::int64_t target_lap_count_{0};
+  bool running_{false};
+  bool completed_{false};
+  std::size_t step_index_{0U};
+};
+
+}  // namespace race_track
+
+#endif  // RACE_TRACK__SINGLE_VEHICLE_RUNTIME_HPP_

--- a/src/race_track/src/race_progress_publisher.cpp
+++ b/src/race_track/src/race_progress_publisher.cpp
@@ -9,11 +9,9 @@
 #include "race_interfaces/msg/race_command.hpp"
 #include "race_interfaces/msg/race_state.hpp"
 #include "race_interfaces/msg/vehicle_race_status.hpp"
-#include "race_track/completion_evaluator.hpp"
-#include "race_track/geometry.hpp"
 #include "race_track/lap_event_assembler.hpp"
-#include "race_track/progress_tracker.hpp"
 #include "race_track/race_state_assembler.hpp"
+#include "race_track/single_vehicle_runtime.hpp"
 #include "race_track/track_loader.hpp"
 #include "race_track/track_validator.hpp"
 #include "race_track/vehicle_race_status_assembler.hpp"
@@ -66,16 +64,13 @@ public:
   explicit RaceProgressPublisher(const std::filesystem::path & sample_track_path)
   : Node("race_progress_publisher"),
     track_(loadTrackFromYaml(sample_track_path.string())),
-    progress_tracker_(track_),
     target_lap_count_(declare_parameter<std::int64_t>("target_lap_count", 2)),
-    positions_(
+    runtime_(
+      track_,
       {{-2.0, 0.0}, {-0.5, 0.2}, {1.0, 0.2}, {6.0, 0.1}, {11.0, 0.4}, {18.0, 4.8},
-       {9.0, 5.0}, {0.5, 0.0}, {-1.0, 0.0}, {1.5, -0.1}, {4.0, 4.0}})
+       {9.0, 5.0}, {0.5, 0.0}, {-1.0, 0.0}, {1.5, -0.1}, {4.0, 4.0}},
+      target_lap_count_)
   {
-    if (target_lap_count_ <= 0) {
-      throw std::runtime_error("target_lap_count must be greater than zero");
-    }
-
     validateTrackOrThrow(track_);
 
     status_publisher_ =
@@ -93,111 +88,76 @@ public:
       sample_track_path.c_str());
     RCLCPP_INFO(get_logger(), "Target lap count: %ld", target_lap_count_);
     RCLCPP_INFO(get_logger(), "Waiting for race commands on /race_command");
-    publishRaceState(currentStepSec(), progress_tracker_.snapshot());
+    publishRaceState(runtime_.current_step_sec(), runtime_.snapshot());
   }
 
 private:
   void onTimer()
   {
-    if (!running_ || completed_) {
+    const SingleVehicleTickResult tick_result = runtime_.tick();
+    if (!tick_result.advanced) {
       return;
     }
 
-    if (step_index_ >= positions_.size()) {
-      running_ = false;
-      return;
+    if (tick_result.crossing_detected) {
+      publishLapEvent(tick_result.step_sec, tick_result.progress_update);
     }
 
-    const std::int32_t step_sec = static_cast<std::int32_t>(step_index_);
-    const Point2d & current = positions_[step_index_];
-    ProgressUpdate progress_update = progress_tracker_.update(step_sec, current);
-    const CompletionDecision decision = completion_evaluator_.evaluate(
-      progress_update.snapshot, step_index_, positions_.size(), target_lap_count_);
-
-    if (decision.should_complete) {
-      running_ = false;
-      completed_ = true;
-      progress_tracker_.setHasFinished(true);
-      progress_update.snapshot = progress_tracker_.snapshot();
-    }
-
-    if (decision.should_stop_without_completion) {
-      running_ = false;
-    }
-
-    if (progress_update.crossing_detected) {
-      publishLapEvent(step_sec, progress_update);
-    }
-
-    publishVehicleRaceStatus(step_sec, progress_update);
-    publishRaceState(step_sec, progress_update.snapshot);
+    publishVehicleRaceStatus(tick_result.step_sec, tick_result.progress_update);
+    publishRaceState(tick_result.step_sec, tick_result.progress_update.snapshot);
 
     RCLCPP_INFO(
       get_logger(),
       "step=%zu position=(%.3f, %.3f) nearest_centerline_index=%zu distance=%.3f "
       "off_track=%s crossing=%s lap_count=%d off_track_count=%d",
-      step_index_, current.x, current.y, progress_update.nearest_centerline_index,
-      progress_update.distance_to_centerline, progress_update.is_off_track ? "true" : "false",
-      progress_update.crossing_detected ? "true" : "false", progress_update.snapshot.lap_count,
-      progress_update.snapshot.off_track_count);
+      runtime_.step_index() - 1U, tick_result.current_position.x, tick_result.current_position.y,
+      tick_result.progress_update.nearest_centerline_index,
+      tick_result.progress_update.distance_to_centerline,
+      tick_result.progress_update.is_off_track ? "true" : "false",
+      tick_result.progress_update.crossing_detected ? "true" : "false",
+      tick_result.progress_update.snapshot.lap_count,
+      tick_result.progress_update.snapshot.off_track_count);
 
-    if (decision.should_complete) {
+    if (tick_result.just_completed) {
       RCLCPP_INFO(
         get_logger(), "Target lap count reached (%d/%ld), marking race completed",
-        progress_update.snapshot.lap_count, target_lap_count_);
+        tick_result.progress_update.snapshot.lap_count, target_lap_count_);
       return;
     }
 
-    if (decision.should_stop_without_completion) {
-      running_ = false;
+    if (tick_result.stopped_without_completion) {
       RCLCPP_WARN(
         get_logger(),
         "Progression stopped at end of fixed positions before reaching target laps (%d/%ld)",
-        progress_update.snapshot.lap_count, target_lap_count_);
-      ++step_index_;
-      return;
+        tick_result.progress_update.snapshot.lap_count, target_lap_count_);
     }
-
-    ++step_index_;
   }
 
   void onRaceCommand(const race_interfaces::msg::RaceCommand::SharedPtr msg)
   {
     switch (msg->command) {
       case race_interfaces::msg::RaceCommand::START:
-        if (completed_ || step_index_ >= positions_.size()) {
+        if (runtime_.start()) {
           RCLCPP_INFO(
             get_logger(), "Received START after completion or final step, resetting progression first");
-          resetProgress();
         }
-        completed_ = false;
-        running_ = true;
-        publishRaceState(currentStepSec(), progress_tracker_.snapshot());
+        publishRaceState(runtime_.current_step_sec(), runtime_.snapshot());
         RCLCPP_INFO(get_logger(), "Received START command, progression started");
         break;
       case race_interfaces::msg::RaceCommand::STOP:
-        running_ = false;
-        completed_ = false;
-        publishRaceState(currentStepSec(), progress_tracker_.snapshot());
+        runtime_.stop();
+        publishRaceState(runtime_.current_step_sec(), runtime_.snapshot());
         RCLCPP_INFO(get_logger(), "Received STOP command, progression stopped");
         break;
       case race_interfaces::msg::RaceCommand::RESET:
-        resetProgress();
-        publishRaceState(currentStepSec(), progress_tracker_.snapshot());
+        runtime_.reset();
+        publishRaceState(runtime_.current_step_sec(), runtime_.snapshot());
         RCLCPP_INFO(get_logger(), "Received RESET command, progression reset");
         break;
       default:
         RCLCPP_WARN(get_logger(), "Received unknown race command: %u", msg->command);
         break;
     }
-  }
-
-  void resetProgress()
-  {
-    running_ = false;
-    completed_ = false;
-    step_index_ = 0U;
-    progress_tracker_.reset();
   }
 
   void publishLapEvent(const std::int32_t step_sec, const ProgressUpdate & progress_update)
@@ -209,7 +169,7 @@ private:
   void publishRaceState(const std::int32_t step_sec, const ProgressSnapshot & snapshot)
   {
     race_interfaces::msg::RaceState race_state =
-      race_state_assembler_.assemble(currentRaceStatus(), step_sec, snapshot);
+      race_state_assembler_.assemble(runtime_.current_race_status(), step_sec, snapshot);
     race_state_publisher_->publish(race_state);
   }
 
@@ -220,41 +180,16 @@ private:
       vehicle_race_status_assembler_.assemble(step_sec, kVehicleId, progress_update));
   }
 
-  std::int32_t currentStepSec() const
-  {
-    if (positions_.empty()) {
-      return 0;
-    }
-
-    const std::size_t clamped_index =
-      step_index_ < positions_.size() ? step_index_ : positions_.size() - 1U;
-    return static_cast<std::int32_t>(clamped_index);
-  }
-
-  std::string currentRaceStatus() const
-  {
-    if (completed_) {
-      return "completed";
-    }
-
-    return running_ ? "running" : "stopped";
-  }
-
   TrackModel track_;
-  ProgressTracker progress_tracker_;
-  SingleVehicleCompletionEvaluator completion_evaluator_;
   LapEventAssembler lap_event_assembler_;
   RaceStateAssembler race_state_assembler_;
   VehicleRaceStatusAssembler vehicle_race_status_assembler_;
-  std::vector<Point2d> positions_;
+  SingleVehicleRuntime runtime_;
   rclcpp::Publisher<race_interfaces::msg::VehicleRaceStatus>::SharedPtr status_publisher_;
   rclcpp::Publisher<race_interfaces::msg::LapEvent>::SharedPtr lap_event_publisher_;
   rclcpp::Publisher<race_interfaces::msg::RaceState>::SharedPtr race_state_publisher_;
   rclcpp::Subscription<race_interfaces::msg::RaceCommand>::SharedPtr command_subscriber_;
   rclcpp::TimerBase::SharedPtr timer_;
-  bool running_{false};
-  bool completed_{false};
-  std::size_t step_index_{0U};
   std::int64_t target_lap_count_{2};
 };
 

--- a/src/race_track/src/single_vehicle_runtime.cpp
+++ b/src/race_track/src/single_vehicle_runtime.cpp
@@ -1,0 +1,128 @@
+#include "race_track/single_vehicle_runtime.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace race_track
+{
+
+SingleVehicleRuntime::SingleVehicleRuntime(
+  const TrackModel & track, std::vector<Point2d> positions, const std::int64_t target_lap_count)
+: progress_tracker_(track),
+  positions_(std::move(positions)),
+  target_lap_count_(target_lap_count)
+{
+  if (target_lap_count_ <= 0) {
+    throw std::runtime_error("target_lap_count must be greater than zero");
+  }
+}
+
+bool SingleVehicleRuntime::start()
+{
+  bool reset_performed = false;
+  if (completed_ || step_index_ >= positions_.size()) {
+    reset();
+    reset_performed = true;
+  }
+
+  completed_ = false;
+  running_ = true;
+  return reset_performed;
+}
+
+bool SingleVehicleRuntime::stop()
+{
+  const bool was_running = running_;
+  running_ = false;
+  completed_ = false;
+  return was_running;
+}
+
+void SingleVehicleRuntime::reset()
+{
+  running_ = false;
+  completed_ = false;
+  step_index_ = 0U;
+  progress_tracker_.reset();
+}
+
+SingleVehicleTickResult SingleVehicleRuntime::tick()
+{
+  SingleVehicleTickResult result;
+
+  if (!running_ || completed_) {
+    return result;
+  }
+
+  if (step_index_ >= positions_.size()) {
+    running_ = false;
+    return result;
+  }
+
+  result.advanced = true;
+  result.step_sec = static_cast<std::int32_t>(step_index_);
+  result.current_position = positions_[step_index_];
+  result.progress_update = progress_tracker_.update(result.step_sec, result.current_position);
+
+  const CompletionDecision decision = completion_evaluator_.evaluate(
+    result.progress_update.snapshot, step_index_, positions_.size(), target_lap_count_);
+
+  if (decision.should_complete) {
+    running_ = false;
+    completed_ = true;
+    progress_tracker_.setHasFinished(true);
+    result.progress_update.snapshot = progress_tracker_.snapshot();
+    result.just_completed = true;
+  }
+
+  if (decision.should_stop_without_completion) {
+    running_ = false;
+    result.stopped_without_completion = true;
+  }
+
+  result.crossing_detected = result.progress_update.crossing_detected;
+  ++step_index_;
+  return result;
+}
+
+bool SingleVehicleRuntime::running() const
+{
+  return running_;
+}
+
+bool SingleVehicleRuntime::completed() const
+{
+  return completed_;
+}
+
+std::size_t SingleVehicleRuntime::step_index() const
+{
+  return step_index_;
+}
+
+std::int32_t SingleVehicleRuntime::current_step_sec() const
+{
+  if (positions_.empty()) {
+    return 0;
+  }
+
+  const std::size_t clamped_index =
+    step_index_ < positions_.size() ? step_index_ : positions_.size() - 1U;
+  return static_cast<std::int32_t>(clamped_index);
+}
+
+std::string SingleVehicleRuntime::current_race_status() const
+{
+  if (completed_) {
+    return "completed";
+  }
+
+  return running_ ? "running" : "stopped";
+}
+
+ProgressSnapshot SingleVehicleRuntime::snapshot() const
+{
+  return progress_tracker_.snapshot();
+}
+
+}  // namespace race_track

--- a/src/race_track/test/test_single_vehicle_runtime.cpp
+++ b/src/race_track/test/test_single_vehicle_runtime.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "race_track/single_vehicle_runtime.hpp"
+
+namespace race_track
+{
+namespace
+{
+
+TrackModel makeTrack()
+{
+  TrackModel track;
+  track.track_name = "unit_test_track";
+  track.centerline = {{0.0, 0.0}, {5.0, 0.0}, {10.0, 0.0}};
+  track.track_width = 4.0;
+  track.start_line = {{0.0, -2.0}, {0.0, 2.0}};
+  track.forward_hint = {1.0, 0.0};
+  return track;
+}
+
+std::vector<Point2d> makePositions()
+{
+  return {{-1.0, 0.0}, {1.0, 0.0}, {-1.0, 0.0}, {1.0, 0.0}, {10.0, 0.0}};
+}
+
+TEST(SingleVehicleRuntimeTest, TickAdvancesAndCompletesWhenTargetLapCountReached)
+{
+  SingleVehicleRuntime runtime(makeTrack(), makePositions(), 2);
+
+  runtime.start();
+
+  const SingleVehicleTickResult first = runtime.tick();
+  EXPECT_TRUE(first.advanced);
+  EXPECT_EQ(first.step_sec, 0);
+  EXPECT_FALSE(first.crossing_detected);
+  EXPECT_TRUE(runtime.running());
+  EXPECT_FALSE(runtime.completed());
+
+  const SingleVehicleTickResult second = runtime.tick();
+  EXPECT_TRUE(second.crossing_detected);
+  EXPECT_EQ(second.progress_update.snapshot.lap_count, 1);
+  EXPECT_TRUE(runtime.running());
+  EXPECT_FALSE(runtime.completed());
+
+  const SingleVehicleTickResult third = runtime.tick();
+  EXPECT_TRUE(third.advanced);
+  EXPECT_FALSE(third.crossing_detected);
+
+  const SingleVehicleTickResult fourth = runtime.tick();
+  EXPECT_TRUE(fourth.advanced);
+  EXPECT_TRUE(fourth.crossing_detected);
+  EXPECT_TRUE(fourth.just_completed);
+  EXPECT_FALSE(fourth.stopped_without_completion);
+  EXPECT_TRUE(fourth.progress_update.snapshot.has_finished);
+  EXPECT_FALSE(runtime.running());
+  EXPECT_TRUE(runtime.completed());
+  EXPECT_EQ(runtime.current_race_status(), "completed");
+}
+
+TEST(SingleVehicleRuntimeTest, StopClearsRunningWithoutResettingProgress)
+{
+  SingleVehicleRuntime runtime(makeTrack(), makePositions(), 2);
+
+  runtime.start();
+  runtime.tick();
+  runtime.tick();
+
+  runtime.stop();
+
+  EXPECT_FALSE(runtime.running());
+  EXPECT_FALSE(runtime.completed());
+  EXPECT_EQ(runtime.step_index(), 2U);
+  EXPECT_EQ(runtime.snapshot().lap_count, 1);
+  EXPECT_EQ(runtime.current_race_status(), "stopped");
+}
+
+TEST(SingleVehicleRuntimeTest, StartAfterCompletionResetsBeforeRunningAgain)
+{
+  SingleVehicleRuntime runtime(makeTrack(), makePositions(), 1);
+
+  runtime.start();
+  runtime.tick();
+  runtime.tick();
+
+  ASSERT_TRUE(runtime.completed());
+  ASSERT_EQ(runtime.snapshot().lap_count, 1);
+
+  runtime.start();
+
+  EXPECT_TRUE(runtime.running());
+  EXPECT_FALSE(runtime.completed());
+  EXPECT_EQ(runtime.step_index(), 0U);
+  EXPECT_EQ(runtime.snapshot().lap_count, 0);
+  EXPECT_EQ(runtime.current_race_status(), "running");
+}
+
+TEST(SingleVehicleRuntimeTest, FinalStepStopsWithoutCompletion)
+{
+  SingleVehicleRuntime runtime(makeTrack(), makePositions(), 3);
+
+  runtime.start();
+
+  SingleVehicleTickResult result;
+  for (std::size_t i = 0; i < makePositions().size(); ++i) {
+    result = runtime.tick();
+  }
+
+  EXPECT_TRUE(result.advanced);
+  EXPECT_TRUE(result.stopped_without_completion);
+  EXPECT_FALSE(result.just_completed);
+  EXPECT_FALSE(runtime.running());
+  EXPECT_FALSE(runtime.completed());
+  EXPECT_EQ(runtime.step_index(), makePositions().size());
+}
+
+}  // namespace
+}  // namespace race_track


### PR DESCRIPTION
## Summary
Extract single-vehicle runtime state and progression logic from `race_progress_publisher` into a dedicated runtime component.

## Changes
- add `SingleVehicleRuntime` to own single-vehicle progression state
- move running/completed/step progression/start-stop-reset logic out of `race_progress_publisher`
- keep ROS I/O and message publishing in the publisher
- add unit tests for runtime behavior
- update `race_track` library/test targets for the new runtime

## Validation
- `colcon build --packages-select race_track race_interfaces`
- `colcon test --packages-select race_track`
- launched `race_progress_demo.launch.py`
- verified `start`, `stop`, and `reset` still work
- verified target-lap completion behavior remains unchanged
- verified stop-without-completion behavior remains unchanged

## Out of scope
- multi-vehicle support
- message definition changes
- launch / CLI changes
- race manager node design